### PR TITLE
Add TimeSpan to KeyTime converter

### DIFF
--- a/src/net35/Radical.Windows/Presentation/Converters/TimeSpanToKeyTimeConverter.cs
+++ b/src/net35/Radical.Windows/Presentation/Converters/TimeSpanToKeyTimeConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Markup;
+using System.Windows.Media.Animation;
+using Topics.Radical.Validation;
+using Topics.Radical.Windows.Converters;
+
+namespace Topics.Radical.Windows.Presentation.Converters
+{
+    [MarkupExtensionReturnType(typeof(TimeSpanToKeyTimeConverter))]
+    public class TimeSpanToKeyTimeConverter : AbstractSingletonConverter
+    {
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            Ensure.That(value).IsNotNull().IsTrue(o => o is TimeSpan);
+            Ensure.That(targetType).IsNotNull().Is(typeof(KeyTime));
+
+            var actual = (TimeSpan)value;
+            var keyTime = KeyTime.FromTimeSpan(actual);
+
+            return keyTime;
+        }
+
+        public override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            Ensure.That(value).IsNotNull().IsTrue(o => o is KeyTime);
+            Ensure.That(targetType).IsNotNull().Is(typeof(TimeSpan));
+
+            var actual = (KeyTime)value;
+            var timeSpan = actual.TimeSpan;
+
+            return timeSpan;
+        }
+    }
+}

--- a/src/net35/Radical.Windows/Radical.Windows.csproj
+++ b/src/net35/Radical.Windows/Radical.Windows.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Presentation\Controls\VisualTargetPresentationSource.cs" />
     <Compile Include="Presentation\Converters\BooleanConverter.cs" />
     <Compile Include="Presentation\Converters\NullToVisibilityConverter.cs" />
+    <Compile Include="Presentation\Converters\TimeSpanToKeyTimeConverter.cs" />
     <Compile Include="Presentation\Extensions\DelegateCommandExtensions.cs" />
     <Compile Include="Presentation\CommandBuilders\BooleanFact.cs" />
     <Compile Include="Presentation\CommandBuilders\CommandData.cs" />


### PR DESCRIPTION
Just added a new converter to convert a TimeSpan into a KeyTime to allow using it to bind the KeyTime property of a animation key frame:

``` xml
<DoubleAnimationUsingKeyFrames Storyboard.TargetName="MyTextBlock"
                               Storyboard.TargetProperty="Opacity">

    <DiscreteDoubleKeyFrame Value="1"
                            KeyTime="{Binding Path=TimeToBind, Converter={converters:TimeSpanToKeyTimeConverter}}" />

</DoubleAnimationUsingKeyFrames>
```
