### PR TITLE
Subscrition callback filters support

### DIFF
--- a/src/net35/Radical/ComponentModel/Messaging/IMessageBroker.cs
+++ b/src/net35/Radical/ComponentModel/Messaging/IMessageBroker.cs
@@ -5,7 +5,7 @@ namespace Topics.Radical.ComponentModel.Messaging
     /// <summary>
     /// Defines the invocation model for the message subscription.
     /// </summary>
-    public enum InvocationModel
+    public enum InvocationModel 
     {
         /// <summary>
         /// The subscriber is invoked in the context and thread of the dispatcher of the message.
@@ -14,20 +14,20 @@ namespace Topics.Radical.ComponentModel.Messaging
         Default,
 
         /// <summary>
-        /// The subscriber is invoked in the main thread marshaling the call even
+        /// The subscriber is invoked in the main thread marshaling the call even 
         /// if the message has been broadcasted.
         /// </summary>
         Safe
     }
 
     /// <summary>
-    /// A message broker is a mediator used to dispatch and
+    /// A message broker is a mediator used to dispatch and 
     /// broadcast messages to all the subscribers in the system.
     /// </summary>
     public interface IMessageBroker
     {
         /// <summary>
-        /// Subscribes the given subscriber to notifications of the
+        /// Subscribes the given subscriber to notifications of the 
         /// given type of IMessage using the supplied callback.
         /// </summary>
         /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
@@ -38,7 +38,7 @@ namespace Topics.Radical.ComponentModel.Messaging
             where T : class, IMessage;
 
         /// <summary>
-        /// Subscribes the given subscriber to notifications of the
+        /// Subscribes the given subscriber to notifications of the 
         /// given type of IMessage using the supplied callback.
         /// </summary>
         /// <param name="subscriber">The subscriber.</param>
@@ -173,23 +173,6 @@ namespace Topics.Radical.ComponentModel.Messaging
         /// <param name="callback">The callback.</param>
         void Subscribe<T>( object subscriber, Action<object, T> callback );
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
         /// <summary>
         /// Subscribes the given subscriber to notifications of the
         /// given type of message using the supplied callback only
@@ -245,60 +228,7 @@ namespace Topics.Radical.ComponentModel.Messaging
         /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
         /// <param name="callback">The callback.</param>
         void Subscribe<T>(object subscriber, Func<object, T, bool> callbackFilter, Action<object, T> callback);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
 #if FX45
 
         /// <summary>
@@ -354,21 +284,7 @@ namespace Topics.Radical.ComponentModel.Messaging
         /// <param name="invocationModel">The invocation model.</param>
         /// <param name="callback">The callback.</param>
         void Subscribe<T>( object subscriber, InvocationModel invocationModel, Action<object, T> callback );
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
         /// <summary>
         /// Subscribes the given subscriber to notifications of the
         /// given type of message using the supplied callback only
@@ -404,22 +320,6 @@ namespace Topics.Radical.ComponentModel.Messaging
         /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
         /// <param name="callback">The callback.</param>
         void Subscribe<T>(object subscriber, InvocationModel invocationModel, Func<object, T, bool> callbackFilter, Action<object, T> callback);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
         /// <summary>
         /// Unsubscribes the specified subscriber from all the subcscriptions.

--- a/src/net35/Radical/ComponentModel/Messaging/IMessageBroker.cs
+++ b/src/net35/Radical/ComponentModel/Messaging/IMessageBroker.cs
@@ -5,7 +5,7 @@ namespace Topics.Radical.ComponentModel.Messaging
     /// <summary>
     /// Defines the invocation model for the message subscription.
     /// </summary>
-    public enum InvocationModel 
+    public enum InvocationModel
     {
         /// <summary>
         /// The subscriber is invoked in the context and thread of the dispatcher of the message.
@@ -14,20 +14,20 @@ namespace Topics.Radical.ComponentModel.Messaging
         Default,
 
         /// <summary>
-        /// The subscriber is invoked in the main thread marshaling the call even 
+        /// The subscriber is invoked in the main thread marshaling the call even
         /// if the message has been broadcasted.
         /// </summary>
         Safe
     }
 
     /// <summary>
-    /// A message broker is a mediator used to dispatch and 
+    /// A message broker is a mediator used to dispatch and
     /// broadcast messages to all the subscribers in the system.
     /// </summary>
     public interface IMessageBroker
     {
         /// <summary>
-        /// Subscribes the given subscriber to notifications of the 
+        /// Subscribes the given subscriber to notifications of the
         /// given type of IMessage using the supplied callback.
         /// </summary>
         /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
@@ -60,7 +60,7 @@ namespace Topics.Radical.ComponentModel.Messaging
         void Subscribe( Object subscriber, Object sender, Type messageType, Action<IMessage> callback );
 
         /// <summary>
-        /// Subscribes the given subscriber to notifications of the 
+        /// Subscribes the given subscriber to notifications of the
         /// given type of IMessage using the supplied callback only
         /// if the sender is the specified reference.
         /// </summary>
@@ -173,6 +173,132 @@ namespace Topics.Radical.ComponentModel.Messaging
         /// <param name="callback">The callback.</param>
         void Subscribe<T>( object subscriber, Action<object, T> callback );
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only
+        /// if the sender is the specified reference.
+        /// </summary>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="sender">The sender filter.</param>
+        /// <param name="messageType">Type of the message.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
+        void Subscribe(object subscriber, object sender, Type messageType, Func<object, object, bool> callbackFilter, Action<object, object> callback);
+
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only
+        /// if the sender is the specified reference.
+        /// </summary>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="sender">The sender filter.</param>
+        /// <param name="messageType">Type of the message.</param>
+        /// <param name="invocationModel">The invocation model.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
+        void Subscribe(object subscriber, object sender, Type messageType, InvocationModel invocationModel, Func<object, object, bool> callbackFilter, Action<object, object> callback);
+
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only.
+        /// </summary>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="messageType">Type of the message.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
+        void Subscribe(object subscriber, Type messageType, Func<object, object, bool> callbackFilter, Action<object, object> callback);
+
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only.
+        /// </summary>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="messageType">Type of the message.</param>
+        /// <param name="invocationModel">The invocation model.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
+        void Subscribe(object subscriber, Type messageType, InvocationModel invocationModel, Func<object, object, bool> callbackFilter, Action<object, object> callback);
+
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
+        void Subscribe<T>(object subscriber, Func<object, T, bool> callbackFilter, Action<object, T> callback);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #if FX45
 
         /// <summary>
@@ -183,6 +309,16 @@ namespace Topics.Radical.ComponentModel.Messaging
         /// <param name="subscriber">The subscriber.</param>
         /// <param name="callback">The callback.</param>
         void Subscribe<T>(object subscriber, Func<object, T, System.Threading.Tasks.Task> callback);
+
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
+        void Subscribe<T>(object subscriber, Func<object, T, System.Threading.Tasks.Task<bool>> callbackFilter, Func<object, T, System.Threading.Tasks.Task> callback);
 
 #endif
 
@@ -218,6 +354,72 @@ namespace Topics.Radical.ComponentModel.Messaging
         /// <param name="invocationModel">The invocation model.</param>
         /// <param name="callback">The callback.</param>
         void Subscribe<T>( object subscriber, InvocationModel invocationModel, Action<object, T> callback );
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only
+        /// if the sender is the specified reference.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="sender">The sender filter.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
+        void Subscribe<T>(object subscriber, object sender, Func<object, T, bool> callbackFilter, Action<object, T> callback);
+
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only
+        /// if the sender is the specified reference.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="sender">The sender filter.</param>
+        /// <param name="invocationModel">The invocation model.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
+        void Subscribe<T>(object subscriber, object sender, InvocationModel invocationModel, Func<object, T, bool> callbackFilter, Action<object, T> callback);
+
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="invocationModel">The invocation model.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
+        void Subscribe<T>(object subscriber, InvocationModel invocationModel, Func<object, T, bool> callbackFilter, Action<object, T> callback);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
         /// <summary>
         /// Unsubscribes the specified subscriber from all the subcscriptions.
@@ -321,7 +523,7 @@ namespace Topics.Radical.ComponentModel.Messaging
         void Dispatch( Object sender, Object message );
 
         /// <summary>
-        /// Dispatches the specified message in a synchronus manner waiting for 
+        /// Dispatches the specified message in a synchronus manner waiting for
         /// the execution of all the subscribers.
         /// </summary>
         /// <typeparam name="T">The type of the message.</typeparam>

--- a/src/net35/Radical/Messaging/MessageBroker.cs
+++ b/src/net35/Radical/Messaging/MessageBroker.cs
@@ -269,12 +269,7 @@ namespace Topics.Radical.Messaging
         /// <param name="callback">The callback.</param>
         public void Subscribe<T>(object subscriber, InvocationModel invocationModel, Action<Object, T> callback)
         {
-            Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
-            Ensure.That(callback).Named(() => callback).IsNotNull();
-
-            var subscription = new PocoSubscription<T>(subscriber, callback, invocationModel, this.dispatcher);
-
-            this.SubscribeCore(typeof(T), subscription);
+            this.Subscribe<T>(subscriber, invocationModel, (s, msg) => true, callback);
         }
 
         /// <summary>
@@ -306,13 +301,7 @@ namespace Topics.Radical.Messaging
         /// <param name="callback">The callback.</param>
         public void Subscribe(object subscriber, Type messageType, InvocationModel invocationModel, Action<Object, Object> callback)
         {
-            Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
-            Ensure.That(messageType).Named(() => messageType).IsNotNull(); //.IsTrue( o => o.Is<IMessage>() );
-            Ensure.That(callback).Named(() => callback).IsNotNull();
-
-            var subscription = new PocoSubscription(subscriber, callback, invocationModel, this.dispatcher);
-
-            this.SubscribeCore(messageType, subscription);
+            this.Subscribe(subscriber, messageType, invocationModel, (s, msg) => true, callback);
         }
 
         /// <summary>
@@ -349,14 +338,7 @@ namespace Topics.Radical.Messaging
         /// <param name="callback">The callback.</param>
         public void Subscribe(object subscriber, object sender, Type messageType, InvocationModel invocationModel, Action<Object, Object> callback)
         {
-            Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
-            Ensure.That(sender).Named(() => sender).IsNotNull();
-            Ensure.That(messageType).Named(() => messageType).IsNotNull().IsTrue(o => o.Is<IMessage>());
-            Ensure.That(callback).Named(() => callback).IsNotNull();
-
-            var subscription = new PocoSubscription(subscriber, sender, callback, invocationModel, this.dispatcher);
-
-            this.SubscribeCore(messageType, subscription);
+            this.Subscribe(subscriber, sender, messageType, invocationModel, (s, msg) => true, callback);
         }
 
         /// <summary>
@@ -392,13 +374,7 @@ namespace Topics.Radical.Messaging
         /// <param name="callback">The callback.</param>
         public void Subscribe<T>(object subscriber, object sender, InvocationModel invocationModel, Action<Object, T> callback)
         {
-            Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
-            Ensure.That(sender).Named(() => sender).IsNotNull();
-            Ensure.That(callback).Named(() => callback).IsNotNull();
-
-            var subscription = new PocoSubscription<T>(subscriber, sender, callback, invocationModel, this.dispatcher);
-
-            this.SubscribeCore(typeof(T), subscription);
+            this.Subscribe<T>(subscriber, sender, invocationModel, (s, msg) => true, callback);
         }
 
         /// <summary>
@@ -696,7 +672,9 @@ namespace Topics.Radical.Messaging
             }
             else
             {
-                subscriptions.ForEach(subscription => subscription.DirectInvoke(message.Sender, message));
+                subscriptions
+                    .Where(sub => sub.ShouldInvoke(message.Sender, message))
+                    .ForEach(subscription => subscription.DirectInvoke(message.Sender, message));
             }
         }
 
@@ -718,7 +696,9 @@ namespace Topics.Radical.Messaging
             }
             else
             {
-                subscriptions.ForEach(subscription => subscription.DirectInvoke(sender, message));
+                subscriptions
+                    .Where(sub => sub.ShouldInvoke(sender, message))
+                    .ForEach(subscription => subscription.DirectInvoke(sender, message));
             }
         }
 #endif
@@ -751,21 +731,24 @@ namespace Topics.Radical.Messaging
 
             if (subscriptions.Any())
             {
+
+                subscriptions.Where(sub => sub.ShouldInvoke(message.Sender, message))
+                    .ForEach(sub =>
+                    {
 #if FX40
-                subscriptions.ForEach(sub =>
-               {
-                   this.factory.StartNew(() =>
-                   {
-                       sub.Invoke(message.Sender, message);
-                   });
-               });
+                        this.factory.StartNew(() =>
+                        {
+                            sub.Invoke(message.Sender, message);
+                        });
 #else
-                subscriptions.ForEach( sub => ThreadPool.QueueUserWorkItem( o =>
-                {
-                    var msg = ( IMessage )o;
-                    sub.Invoke( msg.Sender, msg );
-                }, message ) );
+                        ThreadPool.QueueUserWorkItem( o =>
+                        {
+                            var msg = ( IMessage )o;
+                            sub.Invoke( msg.Sender, msg );
+                        }, message );
 #endif
+                    });
+
             }
         }
 
@@ -781,21 +764,23 @@ namespace Topics.Radical.Messaging
 
             if (subscriptions.Any())
             {
+
+                subscriptions.Where(sub => sub.ShouldInvoke(sender, message))
+                    .ForEach(sub =>
+                    {
 #if FX40
-                subscriptions.ForEach(sub =>
-               {
-                   this.factory.StartNew(() =>
-                   {
-                       sub.Invoke(sender, message);
-                   });
-               });
+                        this.factory.StartNew(() =>
+                        {
+                            sub.Invoke(sender, message);
+                        });
 #else
-                subscriptions.ForEach( sub => ThreadPool.QueueUserWorkItem( o =>
-                {
-                    var state = ( Object[] )o;
-                    sub.Invoke( state[ 0 ], state[ 1 ] );
-                }, new[] { sender, message } ) );
+                        ThreadPool.QueueUserWorkItem( o =>
+                        {
+                            var state = ( Object[] )o;
+                            sub.Invoke( state[ 0 ], state[ 1 ] );
+                        }, new[] { sender, message } );
 #endif
+                    });
             }
         }
 
@@ -819,21 +804,23 @@ namespace Topics.Radical.Messaging
             var tasks = new List<Task>();
             if (subscriptions.Any())
             {
-                subscriptions.ForEach(sub =>
-               {
-                   var _as = sub as IAsyncSubscription;
-                   if (_as != null)
-                   {
-                       tasks.Add(_as.InvokeAsync(sender, message));
-                   }
-                   else
-                   {
-                       tasks.Add(this.factory.StartNew(() =>
-                       {
-                           sub.Invoke(sender, message);
-                       }));
-                   }
-               });
+                subscriptions
+                    .Where(sub => sub.ShouldInvoke(sender, message))
+                    .ForEach(sub =>
+                    {
+                        var _as = sub as IAsyncSubscription;
+                        if (_as != null)
+                        {
+                            tasks.Add(_as.InvokeAsync(sender, message));
+                        }
+                        else
+                        {
+                            tasks.Add(this.factory.StartNew(() =>
+                            {
+                                sub.Invoke(sender, message);
+                            }));
+                        }
+                    });
 
             }
 
@@ -842,14 +829,87 @@ namespace Topics.Radical.Messaging
 
         public void Subscribe<T>(object subscriber, Func<object, T, Task> callback)
         {
-            Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
-            Ensure.That(callback).Named(() => callback).IsNotNull();
+            this.Subscribe(subscriber, (s, msg) => Task.FromResult(true), callback);
+        }
 
-            var subscription = new PocoAsyncSubscription<T>(subscriber, callback, InvocationModel.Default, this.dispatcher);
+        public void Subscribe<T>(object subscriber, Func<object, T, Task<bool>> callbackFilter, Func<object, T, Task> callback)
+        {
+            Ensure.That(subscriber).Named("subscriber").IsNotNull();
+            Ensure.That(callbackFilter).Named("callbackFilter").IsNotNull();
+            Ensure.That(callback).Named("callback").IsNotNull();
+
+            var subscription = new PocoAsyncSubscription<T>(subscriber, callback, callbackFilter, InvocationModel.Default, this.dispatcher);
 
             this.SubscribeCore(typeof(T), subscription);
         }
 
 #endif
+        public void Subscribe(object subscriber, object sender, Type messageType, Func<object, object, bool> callbackFilter, Action<object, object> callback)
+        {
+            this.Subscribe(subscriber, sender, messageType, InvocationModel.Default, callbackFilter, callback);
+        }
+
+        public void Subscribe(object subscriber, object sender, Type messageType, InvocationModel invocationModel, Func<object, object, bool> callbackFilter, Action<object, object> callback)
+        {
+            Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
+            Ensure.That(sender).Named(() => sender).IsNotNull();
+            Ensure.That(messageType).Named(() => messageType).IsNotNull().IsTrue(o => o.Is<IMessage>());
+            Ensure.That(callback).Named(() => callback).IsNotNull();
+            Ensure.That(callbackFilter).Named(() => callbackFilter).IsNotNull();
+
+            var subscription = new PocoSubscription(subscriber, sender, callback, callbackFilter, invocationModel, this.dispatcher);
+
+            this.SubscribeCore(messageType, subscription);
+        }
+
+        public void Subscribe(object subscriber, Type messageType, Func<object, object, bool> callbackFilter, Action<object, object> callback)
+        {
+            this.Subscribe(subscriber, messageType, InvocationModel.Default, callbackFilter, callback);
+        }
+
+        public void Subscribe(object subscriber, Type messageType, InvocationModel invocationModel, Func<object, object, bool> callbackFilter, Action<object, object> callback)
+        {
+            Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
+            Ensure.That(messageType).Named(() => messageType).IsNotNull(); //.IsTrue( o => o.Is<IMessage>() );
+            Ensure.That(callbackFilter).Named(() => callbackFilter).IsNotNull();
+            Ensure.That(callback).Named(() => callback).IsNotNull();
+
+            var subscription = new PocoSubscription(subscriber, callback, callbackFilter, invocationModel, this.dispatcher);
+
+            this.SubscribeCore(messageType, subscription);
+        }
+
+        public void Subscribe<T>(object subscriber, Func<object, T, bool> callbackFilter, Action<object, T> callback)
+        {
+            this.Subscribe<T>(subscriber, InvocationModel.Default, callbackFilter, callback);
+        }
+
+        public void Subscribe<T>(object subscriber, object sender, Func<object, T, bool> callbackFilter, Action<object, T> callback)
+        {
+            this.Subscribe<T>(subscriber, sender, InvocationModel.Default, callbackFilter, callback);
+        }
+
+        public void Subscribe<T>(object subscriber, object sender, InvocationModel invocationModel, Func<object, T, bool> callbackFilter, Action<object, T> callback)
+        {
+            Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
+            Ensure.That(sender).Named(() => sender).IsNotNull();
+            Ensure.That(callback).Named(() => callback).IsNotNull();
+            Ensure.That(callbackFilter).Named(() => callbackFilter).IsNotNull();
+
+            var subscription = new PocoSubscription<T>(subscriber, sender, callback, callbackFilter, invocationModel, this.dispatcher);
+
+            this.SubscribeCore(typeof(T), subscription);
+        }
+
+        public void Subscribe<T>(object subscriber, InvocationModel invocationModel, Func<object, T, bool> callbackFilter, Action<object, T> callback)
+        {
+            Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
+            Ensure.That(callback).Named(() => callback).IsNotNull();
+            Ensure.That(callbackFilter).Named(() => callbackFilter).IsNotNull();
+
+            var subscription = new PocoSubscription<T>(subscriber, callback, callbackFilter, invocationModel, this.dispatcher);
+
+            this.SubscribeCore(typeof(T), subscription);
+        }
     }
 }

--- a/src/net35/Radical/Messaging/MessageBroker.cs
+++ b/src/net35/Radical/Messaging/MessageBroker.cs
@@ -752,6 +752,12 @@ namespace Topics.Radical.Messaging
             }
         }
 
+        /// <summary>
+        /// Broadcasts the specified message in an asynchronus manner without
+        /// waiting for the execution of the subscribers.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="message">The message.</param>
         public void Broadcast(Object sender, Object message)
         {
             Ensure.That(message).Named(() => message).IsNotNull();
@@ -827,11 +833,26 @@ namespace Topics.Radical.Messaging
             return Task.WhenAll(tasks.ToArray());
         }
 
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="callback">The callback.</param>
         public void Subscribe<T>(object subscriber, Func<object, T, Task> callback)
         {
             this.Subscribe(subscriber, (s, msg) => Task.FromResult(true), callback);
         }
 
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
         public void Subscribe<T>(object subscriber, Func<object, T, Task<bool>> callbackFilter, Func<object, T, Task> callback)
         {
             Ensure.That(subscriber).Named("subscriber").IsNotNull();
@@ -844,11 +865,32 @@ namespace Topics.Radical.Messaging
         }
 
 #endif
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only
+        /// if the sender is the specified reference.
+        /// </summary>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="sender">The sender filter.</param>
+        /// <param name="messageType">Type of the message.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
         public void Subscribe(object subscriber, object sender, Type messageType, Func<object, object, bool> callbackFilter, Action<object, object> callback)
         {
             this.Subscribe(subscriber, sender, messageType, InvocationModel.Default, callbackFilter, callback);
         }
 
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only
+        /// if the sender is the specified reference.
+        /// </summary>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="sender">The sender filter.</param>
+        /// <param name="messageType">Type of the message.</param>
+        /// <param name="invocationModel">The invocation model.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
         public void Subscribe(object subscriber, object sender, Type messageType, InvocationModel invocationModel, Func<object, object, bool> callbackFilter, Action<object, object> callback)
         {
             Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
@@ -862,11 +904,28 @@ namespace Topics.Radical.Messaging
             this.SubscribeCore(messageType, subscription);
         }
 
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only.
+        /// </summary>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="messageType">Type of the message.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
         public void Subscribe(object subscriber, Type messageType, Func<object, object, bool> callbackFilter, Action<object, object> callback)
         {
             this.Subscribe(subscriber, messageType, InvocationModel.Default, callbackFilter, callback);
         }
 
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only.
+        /// </summary>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="messageType">Type of the message.</param>
+        /// <param name="invocationModel">The invocation model.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
         public void Subscribe(object subscriber, Type messageType, InvocationModel invocationModel, Func<object, object, bool> callbackFilter, Action<object, object> callback)
         {
             Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
@@ -879,16 +938,45 @@ namespace Topics.Radical.Messaging
             this.SubscribeCore(messageType, subscription);
         }
 
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
         public void Subscribe<T>(object subscriber, Func<object, T, bool> callbackFilter, Action<object, T> callback)
         {
             this.Subscribe<T>(subscriber, InvocationModel.Default, callbackFilter, callback);
         }
 
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only
+        /// if the sender is the specified reference.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="sender">The sender filter.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
         public void Subscribe<T>(object subscriber, object sender, Func<object, T, bool> callbackFilter, Action<object, T> callback)
         {
             this.Subscribe<T>(subscriber, sender, InvocationModel.Default, callbackFilter, callback);
         }
 
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback only
+        /// if the sender is the specified reference.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="sender">The sender filter.</param>
+        /// <param name="invocationModel">The invocation model.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
         public void Subscribe<T>(object subscriber, object sender, InvocationModel invocationModel, Func<object, T, bool> callbackFilter, Action<object, T> callback)
         {
             Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
@@ -901,6 +989,15 @@ namespace Topics.Radical.Messaging
             this.SubscribeCore(typeof(T), subscription);
         }
 
+        /// <summary>
+        /// Subscribes the given subscriber to notifications of the
+        /// given type of message using the supplied callback.
+        /// </summary>
+        /// <typeparam name="T">The type of message the subecriber is interested in.</typeparam>
+        /// <param name="subscriber">The subscriber.</param>
+        /// <param name="invocationModel">The invocation model.</param>
+        /// <param name="callbackFilter">The filter invoked to determine if the callback shopuld be invoked.</param>
+        /// <param name="callback">The callback.</param>
         public void Subscribe<T>(object subscriber, InvocationModel invocationModel, Func<object, T, bool> callbackFilter, Action<object, T> callback)
         {
             Ensure.That(subscriber).Named(() => subscriber).IsNotNull();

--- a/src/net40/Test.Radical/Messaging/MessageBrokerTests.cs
+++ b/src/net40/Test.Radical/Messaging/MessageBrokerTests.cs
@@ -520,7 +520,7 @@ namespace Test.Radical.Windows.Messaging
         //public void should_raise_ArgumentException()
         //{
         //    var actual = 0;
-        //    var expected =1; 
+        //    var expected =1;
 
         //    var dispatcher = new NullDispatcher();
         //    var broker = new MessageBroker( dispatcher );
@@ -708,11 +708,11 @@ namespace Test.Radical.Windows.Messaging
             {
                 broker.Subscribe<PocoTestMessage>( this, ( sender, msg ) => { } );
             }
-            
+
             var sw = Stopwatch.StartNew();
             broker.Broadcast(this, new PocoTestMessage());
             sw.Stop();
-            
+
             const int longRunningTiming = 100;
             var elapsedMilliseconds = sw.ElapsedMilliseconds == 0
                 ? longRunningTiming
@@ -792,5 +792,25 @@ namespace Test.Radical.Windows.Messaging
             Assert.IsNull( failure, failure != null ? failure.ToString() : "--" );
 
         }
+
+        //[TestMethod]
+        //[TestCategory("MessageBroker")]
+        //public void messageBroker_POCO_should_respect_should_handle_predicate()
+        //{
+        //    object expected = new PocoTestMessage();
+        //    object actual = null;
+
+        //    var dispatcher = new NullDispatcher();
+        //    var broker = new MessageBroker(dispatcher);
+
+        //    broker.Subscribe<PocoTestMessage>(this, (s,msg) => false, (s,msg) =>
+        //    {
+        //        actual = msg;
+        //    });
+
+        //    broker.Dispatch(this, expected);
+
+        //    Assert.IsNull(actual);
+        //}
     }
 }

--- a/src/net40/Test.Radical/Messaging/MessageBrokerTests.cs
+++ b/src/net40/Test.Radical/Messaging/MessageBrokerTests.cs
@@ -793,24 +793,23 @@ namespace Test.Radical.Windows.Messaging
 
         }
 
-        //[TestMethod]
-        //[TestCategory("MessageBroker")]
-        //public void messageBroker_POCO_should_respect_should_handle_predicate()
-        //{
-        //    object expected = new PocoTestMessage();
-        //    object actual = null;
+        [TestMethod]
+        [TestCategory("MessageBroker")]
+        public void messageBroker_POCO_should_respect_should_handle_predicate()
+        {
+            bool actual = false;
 
-        //    var dispatcher = new NullDispatcher();
-        //    var broker = new MessageBroker(dispatcher);
+            var dispatcher = new NullDispatcher();
+            var broker = new MessageBroker(dispatcher);
 
-        //    broker.Subscribe<PocoTestMessage>(this, (s,msg) => false, (s,msg) =>
-        //    {
-        //        actual = msg;
-        //    });
+            broker.Subscribe<PocoTestMessage>(this, (s, msg) => false, (s, msg) =>
+            {
+                actual = true;
+            });
 
-        //    broker.Dispatch(this, expected);
+            broker.Dispatch(this, new PocoTestMessage());
 
-        //    Assert.IsNull(actual);
-        //}
+            Assert.IsFalse(actual);
+        }
     }
 }

--- a/src/net45/Test.Radical/Messaging/MessageBrokerTests.cs
+++ b/src/net45/Test.Radical/Messaging/MessageBrokerTests.cs
@@ -119,5 +119,25 @@ namespace Test.Radical.Windows.Messaging
 
             Assert.AreEqual(expected, actual);
         }
+
+        [TestMethod]
+        [TestCategory("MessageBroker")]
+        public async Task messageBroker_async_POCO_should_respect_should_handle_predicate()
+        {
+            bool actual = false;
+
+            var dispatcher = new NullDispatcher();
+            var broker = new MessageBroker(dispatcher);
+
+            broker.Subscribe<PocoTestMessage>(this, (s, msg) => false, async (s, msg) =>
+            {
+                actual = true;
+                await Task.FromResult(0);
+            });
+
+            await broker.BroadcastAsync(this, new PocoTestMessage());
+
+            Assert.IsFalse(actual);
+        }
     }
 }


### PR DESCRIPTION
Connects to https://github.com/RadicalFx/Radical/issues/239
Fix https://github.com/RadicalFx/Radical/issues/239

This PR introduce support for subscriptions filters allowing something like the following:

```
broker.Subscribe<MyMessage>( 
   subscriber: this,
   callbackFilter: (s, msg) => { /* filter */ return true; },
   callback: (s, msg) =>{ /* logic */ } 
);
```