### PR TITLE
Fix Wrong subscription ensure in MessageBroker

### DIFF
--- a/src/net35/Radical/Messaging/MessageBroker.cs
+++ b/src/net35/Radical/Messaging/MessageBroker.cs
@@ -895,7 +895,7 @@ namespace Topics.Radical.Messaging
         {
             Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
             Ensure.That(sender).Named(() => sender).IsNotNull();
-            Ensure.That(messageType).Named(() => messageType).IsNotNull().IsTrue(o => o.Is<IMessage>());
+            Ensure.That(messageType).Named(() => messageType).IsNotNull();
             Ensure.That(callback).Named(() => callback).IsNotNull();
             Ensure.That(callbackFilter).Named(() => callbackFilter).IsNotNull();
 
@@ -929,7 +929,7 @@ namespace Topics.Radical.Messaging
         public void Subscribe(object subscriber, Type messageType, InvocationModel invocationModel, Func<object, object, bool> callbackFilter, Action<object, object> callback)
         {
             Ensure.That(subscriber).Named(() => subscriber).IsNotNull();
-            Ensure.That(messageType).Named(() => messageType).IsNotNull(); //.IsTrue( o => o.Is<IMessage>() );
+            Ensure.That(messageType).Named(() => messageType).IsNotNull();
             Ensure.That(callbackFilter).Named(() => callbackFilter).IsNotNull();
             Ensure.That(callback).Named(() => callback).IsNotNull();
 

--- a/src/net40/Test.Radical/Messaging/MessageBrokerTests.cs
+++ b/src/net40/Test.Radical/Messaging/MessageBrokerTests.cs
@@ -811,5 +811,16 @@ namespace Test.Radical.Windows.Messaging
 
             Assert.IsFalse(actual);
         }
+
+        [TestMethod]
+        [TestCategory("MessageBroker")]
+        //BUG: https://github.com/RadicalFx/Radical/issues/241
+        public void messageBroker_should_allow_POCO_subscriptions_and_not_IMessage_ones()
+        {
+            var dispatcher = new NullDispatcher();
+            var broker = new MessageBroker(dispatcher);
+
+            broker.Subscribe(this, this, typeof(PocoTestMessage), InvocationModel.Default, (s, msg) => false, (s, msg) =>{ /* NOP */ });
+        }
     }
 }


### PR DESCRIPTION
Connect to #241 
Fix #241 

Added a test to validate the bug and fixed it.

I don't think this deserves an hotfix, even if it is a bug. It is a long standing one on a `Subscribe` overload that is merely for internal usage.

@micdenny what do you think?