### PR TITLE
Add API Approvals tests

### DIFF
--- a/src/net40/Test.Radical/API/APIApprovals.Approve_FXV40_API.approved.txt
+++ b/src/net40/Test.Radical/API/APIApprovals.Approve_FXV40_API.approved.txt
@@ -1,0 +1,4845 @@
+﻿[assembly: System.CLSCompliantAttribute(true)]
+[assembly: System.Resources.NeutralResourcesLanguageAttribute("en-US", System.Resources.UltimateResourceFallbackLocation.MainAssembly)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Test.Radical35")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Test.Radical40")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Test.Radical45")]
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.InteropServices.GuidAttribute("ac1104e2-8764-42ea-80aa-bfd22bc6a89f")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.0", FrameworkDisplayName=".NET Framework 4")]
+
+namespace Topics.Radical
+{
+    
+    public sealed class ActionTextWriter : System.IO.TextWriter
+    {
+        public ActionTextWriter(System.Action<string> logger) { }
+        public ActionTextWriter(System.Action<string> logger, System.IFormatProvider formatProvider) { }
+        public override System.Text.Encoding Encoding { get; }
+        public override void Write(string value) { }
+        public override void Write(char[] buffer, int index, int count) { }
+    }
+    public class static ArrayExtensions
+    {
+        public static bool IsSameAs<T>(this T[] source, T[] other)
+            where T : System.IComparable { }
+        public static bool IsSameAs<T>(this T[] source, T[] other, System.Func<T, T, bool> itemComparer) { }
+    }
+    public class BootableFacility : Topics.Radical.ComponentModel.IPuzzleContainerFacility
+    {
+        public BootableFacility() { }
+        public void Initialize(Topics.Radical.ComponentModel.IPuzzleContainer container) { }
+        public void Teardown(Topics.Radical.ComponentModel.IPuzzleContainer container) { }
+    }
+    public class static ConsoleColorExtensions
+    {
+        public static System.IDisposable AsForegroundColor(this System.ConsoleColor color) { }
+    }
+    public class static DateTimeExtensions
+    {
+        public static System.DateTime ToEndOfMonth(this System.DateTime source) { }
+    }
+    public sealed class DelegateComparer<T> : System.Collections.Generic.IComparer<T>
+    
+    {
+        public DelegateComparer(System.Func<T, T, int> comparer) { }
+        public int Compare(T x, T y) { }
+    }
+    public sealed class DelegateEqualityComparer<T> : System.Collections.Generic.EqualityComparer<T>
+    
+    {
+        public DelegateEqualityComparer(System.Func<T, T, bool> comparer, System.Func<T, int> hashCodeFunc) { }
+        public override bool Equals(T x, T y) { }
+        public override int GetHashCode(T obj) { }
+    }
+    public class static EntityCollectionExtensions
+    {
+        public static Topics.Radical.ComponentModel.IEntityCollection<T> BulkLoad<T>(this Topics.Radical.ComponentModel.IEntityCollection<T> list, System.Collections.Generic.IEnumerable<T> data)
+            where T :  class { }
+        public static Topics.Radical.ComponentModel.IEntityCollection<T> BulkLoad<T>(this Topics.Radical.ComponentModel.IEntityCollection<T> list, System.Collections.Generic.IEnumerable<T> data, bool clear)
+            where T :  class { }
+        public static Topics.Radical.ComponentModel.IEntityCollection<T> BulkLoad<T, TSource>(this Topics.Radical.ComponentModel.IEntityCollection<T> list, System.Collections.Generic.IEnumerable<TSource> data, System.Func<TSource, T> adapter)
+            where T :  class { }
+    }
+    public class static EntityViewExtensions
+    {
+        public static Topics.Radical.ComponentModel.IEntityView<T> ApplySimpleSort<T>(this Topics.Radical.ComponentModel.IEntityView<T> view, string property)
+            where T :  class { }
+        public static System.Collections.Generic.IEnumerable<T> AsEntityItems<T>(this Topics.Radical.ComponentModel.IEntityView<T> view)
+            where T :  class { }
+    }
+    public class static EntryBuilder
+    {
+        public static Topics.Radical.ComponentModel.IPuzzleContainerEntry For(System.Type type) { }
+        public static Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> For<T>() { }
+    }
+    public class static EnumExtensions
+    {
+        public static void EnsureIsDefined(this System.Enum value) { }
+        public static string GetCaption(this System.Enum value) { }
+        public static string GetDescription(this System.Enum value) { }
+        public static Topics.Radical.EnumItemDescriptionAttribute GetDescriptionAttribute(this System.Enum value) { }
+        public static bool IsDefined(this System.Enum value) { }
+        public static bool IsDescriptionAttributeDefined(this System.Enum value) { }
+        public static bool TryGetDescriptionAttribute(this System.Enum value, out Topics.Radical.EnumItemDescriptionAttribute attribute) { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    public class EnumItemDescriptionAttribute : System.Attribute
+    {
+        public EnumItemDescriptionAttribute(string caption) { }
+        public EnumItemDescriptionAttribute(string caption, int index) { }
+        public EnumItemDescriptionAttribute(string caption, string description, int index) { }
+        public string Caption { get; }
+        public string Description { get; }
+        public virtual int Index { get; }
+        protected virtual string OnGetCaption(string caption) { }
+        protected virtual string OnGetDescription(string description) { }
+    }
+    public class EnumValueOutOfRangeException : System.ArgumentException
+    {
+        protected EnumValueOutOfRangeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public EnumValueOutOfRangeException() { }
+        public EnumValueOutOfRangeException(string message) { }
+        public EnumValueOutOfRangeException(string message, System.Exception innerException) { }
+    }
+    public class InvalidKeyFormatException : Topics.Radical.RadicalException
+    {
+        protected InvalidKeyFormatException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidKeyFormatException() { }
+        public InvalidKeyFormatException(string message) { }
+        public InvalidKeyFormatException(string message, System.Exception innerException) { }
+    }
+    public class static IServiceProviderExtensions
+    {
+        public static TService GetService<TService>(this System.IServiceProvider serviceProvider) { }
+        public static TInterface GetService<SInterface, TInterface>(this System.IServiceProvider serviceProvider) { }
+        public static TService TryGetService<TService>(this System.IServiceProvider serviceProvider) { }
+        public static TInterface TryGetService<SInterface, TInterface>(this System.IServiceProvider serviceProvider) { }
+    }
+    [System.CLSCompliantAttribute(false)]
+    public abstract class Key : System.IComparable, System.IEquatable<Topics.Radical.ComponentModel.IKey>, Topics.Radical.ComponentModel.IKey
+    {
+        protected Key() { }
+        public abstract bool IsEmpty { get; }
+        public abstract int CompareTo(object obj);
+        public abstract bool Equals(Topics.Radical.ComponentModel.IKey other);
+        public virtual int GetHashCode() { }
+    }
+    [System.CLSCompliantAttribute(false)]
+    public class Key<T> : Topics.Radical.Key, System.IComparable, System.IComparable<Topics.Radical.ComponentModel.IKey<T>>, System.IEquatable<Topics.Radical.ComponentModel.IKey<T>>, System.IEquatable<Topics.Radical.ComponentModel.IKey>, Topics.Radical.ComponentModel.IKey, Topics.Radical.ComponentModel.IKey<T>
+        where T : System.IComparable, System.IComparable<>
+    {
+        public Key() { }
+        public Key(T value) { }
+        public override bool IsEmpty { get; }
+        public T Value { get; }
+        public override int CompareTo(object obj) { }
+        public int CompareTo(Topics.Radical.ComponentModel.IKey<T> other) { }
+        public override bool Equals(object obj) { }
+        public override bool Equals(Topics.Radical.ComponentModel.IKey other) { }
+        public bool Equals(Topics.Radical.ComponentModel.IKey<T> other) { }
+        public static bool Equals(Topics.Radical.ComponentModel.IKey<T> leftValue, Topics.Radical.ComponentModel.IKey<T> rightValue) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+    }
+    public class static KeyExtensions
+    {
+        public static T ValueOr<T>(this Topics.Radical.ComponentModel.IKey value, T defaultValue)
+            where T : System.IComparable, System.IComparable<> { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    public class LocalizableEnumItemDescriptionAttribute : Topics.Radical.EnumItemDescriptionAttribute
+    {
+        public LocalizableEnumItemDescriptionAttribute(string captionKey) { }
+        public LocalizableEnumItemDescriptionAttribute(string captionKey, int index) { }
+        public LocalizableEnumItemDescriptionAttribute(string captionKey, string descriptionKey, int index) { }
+        public Topics.Radical.ResourceAssemblyLocationBehavior AssemblyLocationBehavior { get; set; }
+        public string AssemblyName { get; set; }
+        public string CaptionFallbackValue { get; set; }
+        public string DescriptionFallbackValue { get; set; }
+        protected System.Resources.ResourceManager ResourceManager { get; }
+        public string ResourceName { get; set; }
+        protected override string OnGetCaption(string caption) { }
+        protected override string OnGetDescription(string description) { }
+    }
+    public class MissingContractAttributeException : Topics.Radical.RadicalException
+    {
+        protected MissingContractAttributeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public MissingContractAttributeException() { }
+        public MissingContractAttributeException(System.Type targetType) { }
+        public MissingContractAttributeException(string message) { }
+        public MissingContractAttributeException(string message, System.Exception innerException) { }
+        public System.Type TargetType { get; }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class static NullableExtensions
+    {
+        public static T ValueOr<T>(this System.Nullable<T> value, T defaultValue)
+            where T :  struct { }
+        public static T ValueOr<T>(this System.Nullable<T> value, T defaultValue, System.Func<T, T> ifValue)
+            where T :  struct { }
+    }
+    public class static NumbersExtensions
+    {
+        public static bool IsEven(this int value) { }
+    }
+    public class static ObjectExtensions
+    {
+        public static TInput Do<TInput>(this TInput input, System.Action<TInput> action) { }
+        public static TInput Do<TInput>(this TInput input, System.Predicate<TInput> failureEvaluator, System.Action<TInput> action) { }
+        public static T If<T>(this T obj, System.Predicate<T> condition, System.Action<T> thenAction)
+            where T :  class { }
+        public static T If<T>(this T obj, System.Predicate<T> condition, System.Action<T> thenAction, System.Action<T> elseAction)
+            where T :  class { }
+        public static TInput If<TInput>(this TInput o, System.Func<TInput, bool> evaluator)
+            where TInput :  class { }
+        [System.ObsoleteAttribute()]
+        public static T IfNotNullDo<T>(this T obj, System.Action<T> action) { }
+        [System.ObsoleteAttribute()]
+        public static T IfNullDo<T>(this T obj, System.Action action) { }
+        [System.ObsoleteAttribute()]
+        public static T Intercept<T>(this T obj, System.Action<T> interceptor) { }
+        public static TSource InterceptAs<TSource, TDestination>(this TSource obj, System.Action<TDestination> interceptor)
+            where TSource :  class
+            where TDestination :  class { }
+        public static TResult Return<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator) { }
+        public static TResult Return<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, TResult defaultValueOnNullInput) { }
+        public static TResult Return<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, TResult failureValue, System.Predicate<TInput> failureEvaluator) { }
+        public static TResult Return<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, System.Func<TResult> defaultValueOnNullInput) { }
+        public static TResult Return<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, System.Func<TResult> failureValue, System.Predicate<TInput> failureEvaluator) { }
+        public static TInput Unless<TInput>(this TInput o, System.Func<TInput, bool> evaluator)
+            where TInput :  class { }
+        public static TResult With<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator) { }
+        public static TResult With<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, TResult defaultValueOnNullInput) { }
+        public static TResult With<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, System.Func<TResult> defaultValueOnNullInput) { }
+        public static TResult With<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, System.Predicate<TInput> failureEvaluator, System.Func<TResult> failureValue) { }
+    }
+    public class Observable<T> : System.ComponentModel.INotifyPropertyChanged
+    
+    {
+        public Observable() { }
+        public Observable(T value) { }
+        public virtual T Value { get; set; }
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        protected virtual void OnPropertyChanged() { }
+    }
+    public class PuzzleContainer : System.IDisposable, Topics.Radical.ComponentModel.IPuzzleContainer
+    {
+        public PuzzleContainer() { }
+        public event System.EventHandler<Topics.Radical.ComponentModel.ComponentRegisteredEventArgs> ComponentRegistered;
+        public Topics.Radical.ComponentModel.IPuzzleContainer AddFacility(Topics.Radical.ComponentModel.IPuzzleContainerFacility facility) { }
+        public Topics.Radical.ComponentModel.IPuzzleContainer AddFacility<TFacility>()
+            where TFacility : Topics.Radical.ComponentModel.IPuzzleContainerFacility { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        protected override void Finalize() { }
+        public System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IPuzzleContainerFacility> GetFacilities() { }
+        public object GetService(System.Type serviceType) { }
+        public bool IsRegistered<TService>() { }
+        public bool IsRegistered(System.Type type) { }
+        protected virtual void OnComponentRegistered(Topics.Radical.ComponentModel.ComponentRegisteredEventArgs e) { }
+        public Topics.Radical.ComponentModel.IPuzzleContainer Register(Topics.Radical.ComponentModel.IContainerEntry entry) { }
+        public Topics.Radical.ComponentModel.IPuzzleContainer Register(System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IContainerEntry> entries) { }
+        public TService Resolve<TService>() { }
+        public object Resolve(System.Type serviceType) { }
+        public object Resolve(string key, System.Type serviceType) { }
+        public System.Collections.Generic.IEnumerable<T> ResolveAll<T>() { }
+        public System.Collections.Generic.IEnumerable<object> ResolveAll(System.Type t) { }
+        public void SetupWith(System.Func<System.Collections.Generic.IEnumerable<System.Type>> knownTypesProvider, params Topics.Radical.ComponentModel.IPuzzleSetupDescriptor[] descriptors) { }
+    }
+    public class PuzzleContainerServiceProviderFacade : System.IServiceProvider
+    {
+        public PuzzleContainerServiceProviderFacade(Topics.Radical.ComponentModel.IPuzzleContainer container) { }
+        public object GetService(System.Type serviceType) { }
+    }
+    public class RadicalException : System.Exception
+    {
+        protected RadicalException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public RadicalException() { }
+        public RadicalException(string message) { }
+        public RadicalException(string message, System.Exception innerException) { }
+    }
+    public enum ResourceAssemblyLocationBehavior
+    {
+        ByAssemblyName = 0,
+        UseExecutingAssembly = 1,
+        UseCallingAssembly = 2,
+        UseEntryAssembly = 3,
+    }
+    public class static StringExtensions
+    {
+        public static string Append(this string value, string text) { }
+        public static System.Collections.Generic.IEnumerable<string> AsKeywords(this string source, params char[] separators) { }
+        public static System.Collections.Generic.IEnumerable<string> AsKeywords(this string source, bool applyWildChardsIfNecessary, params char[] separators) { }
+        public static string AsPackUri(this string resourceRelativeUri) { }
+        public static string AsPackUri(this string resourceRelativeUri, string assemblyName) { }
+        public static string IfNullOrEmptyReturn(this string value, string defaultValue) { }
+        public static bool IsLike(this string value, string pattern) { }
+        public static bool IsLike(this string value, params string[] patterns) { }
+        public static bool IsLike(this string value, string pattern, bool ignoreCase) { }
+        public static bool IsNullOrEmpty(this string value) { }
+        public static string ValueOr(this string value, string defaultValue) { }
+        public static string ValueOr(this string value, string defaultValue, System.Func<string, string> ifValue) { }
+        public static string ValueOrEmpty(this string value) { }
+        public static string ValueOrEmpty(this string value, System.Func<string, string> ifValue) { }
+    }
+    public sealed class SubscribeToMessageFacility : Topics.Radical.ComponentModel.IPuzzleContainerFacility
+    {
+        public SubscribeToMessageFacility() { }
+        public void Initialize(Topics.Radical.ComponentModel.IPuzzleContainer container) { }
+        public void Teardown(Topics.Radical.ComponentModel.IPuzzleContainer container) { }
+    }
+    public class SuspendedChangeTrackingServiceException : Topics.Radical.RadicalException
+    {
+        protected SuspendedChangeTrackingServiceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public SuspendedChangeTrackingServiceException() { }
+        public SuspendedChangeTrackingServiceException(string message) { }
+        public SuspendedChangeTrackingServiceException(string message, System.Exception innerException) { }
+    }
+    public class WeakReference<T> : System.WeakReference
+        where T :  class
+    {
+        public WeakReference(T target) { }
+        public WeakReference(T target, bool trackResurrection) { }
+        protected WeakReference(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public T Target { get; set; }
+    }
+}
+namespace Topics.Radical.Analytics
+{
+    
+    public class AnalyticsEvent
+    {
+        public AnalyticsEvent() { }
+        public object Data { get; set; }
+        public System.DateTimeOffset ExecutedOn { get; set; }
+        public System.Security.Principal.IIdentity Identity { get; set; }
+        public string Name { get; set; }
+    }
+    public class static AnalyticsServices
+    {
+        public static bool IsEnabled { get; set; }
+        public static System.Action<Topics.Radical.Analytics.AnalyticsEvent> UserActionTrackingHandler { get; set; }
+        public static void TrackUserActionAsync(Topics.Radical.Analytics.AnalyticsEvent action) { }
+    }
+}
+namespace Topics.Radical.ChangeTracking
+{
+    
+    public class AdvisedAction : Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction
+    {
+        public AdvisedAction(object target, Topics.Radical.ComponentModel.ChangeTracking.ProposedActions action) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.ProposedActions Action { get; }
+        public object Target { get; }
+    }
+    public class Advisory : Topics.Radical.Collections.ReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction>, System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction>, System.Collections.ICollection, System.Collections.IEnumerable, Topics.Radical.ComponentModel.ChangeTracking.IAdvisory, Topics.Radical.ComponentModel.IReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction>
+    {
+        public Advisory(System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction> actions) { }
+    }
+    public class AdvisoryBuilder : Topics.Radical.ComponentModel.ChangeTracking.IAdvisoryBuilder
+    {
+        public AdvisoryBuilder(Topics.Radical.ComponentModel.ChangeTracking.IChangeSetDistinctVisitor visitor) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GenerateAdvisory(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService svc, Topics.Radical.ComponentModel.ChangeTracking.IChangeSet changeSet) { }
+        protected virtual Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction OnCreateAdvisedAction(object target, Topics.Radical.ComponentModel.ChangeTracking.ProposedActions proposedAction) { }
+    }
+    public class Bookmark : Topics.Radical.ComponentModel.ChangeTracking.IBookmark
+    {
+        public Bookmark(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService owner, Topics.Radical.ComponentModel.ChangeTracking.IChange position, System.Collections.Generic.IEnumerable<object> transientEntities) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Owner { get; }
+        public Topics.Radical.ComponentModel.ChangeTracking.IChange Position { get; }
+        public System.Collections.Generic.IEnumerable<object> TransientEntities { get; }
+    }
+    public abstract class Change<T> : Topics.Radical.ComponentModel.ChangeTracking.IChange, Topics.Radical.ComponentModel.ChangeTracking.IChange<T>
+    
+    {
+        protected Change(object owner, T valueToCache, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> commitCallback, string description) { }
+        public T CachedValue { get; }
+        protected Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> CommitCallback { get; }
+        public string Description { get; }
+        public virtual bool IsCommitSupported { get; }
+        public object Owner { get; }
+        protected Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> RejectCallback { get; }
+        public event System.EventHandler<Topics.Radical.ComponentModel.ChangeTracking.CommittedEventArgs> Committed;
+        public event System.EventHandler<Topics.Radical.ComponentModel.ChangeTracking.RejectedEventArgs> Rejected;
+        public abstract Topics.Radical.ComponentModel.ChangeTracking.IChange Clone();
+        public void Commit(Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason) { }
+        public abstract Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem);
+        public virtual System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+        protected virtual void OnCommit(Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason) { }
+        protected virtual void OnCommitted(Topics.Radical.ComponentModel.ChangeTracking.CommittedEventArgs args) { }
+        protected virtual void OnReject(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        protected virtual void OnRejected(Topics.Radical.ComponentModel.ChangeTracking.RejectedEventArgs args) { }
+        public void Reject(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+    }
+    public class ChangeSet : Topics.Radical.Collections.ReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IChange>, System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IChange>, System.Collections.ICollection, System.Collections.IEnumerable, Topics.Radical.ComponentModel.ChangeTracking.IChangeSet, Topics.Radical.ComponentModel.IReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IChange>
+    {
+        public ChangeSet(System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IChange> changes) { }
+    }
+    public class ChangeSetDistinctVisitor : Topics.Radical.ComponentModel.ChangeTracking.IChangeSetDistinctVisitor
+    {
+        public ChangeSetDistinctVisitor() { }
+        public System.Collections.Generic.IDictionary<object, Topics.Radical.ComponentModel.ChangeTracking.IChange> Visit(Topics.Radical.ComponentModel.ChangeTracking.IChangeSet changeSet) { }
+    }
+    [System.ComponentModel.ToolboxItemAttribute(false)]
+    public class ChangeTrackingService : System.ComponentModel.IChangeTracking, System.ComponentModel.IComponent, System.ComponentModel.IRevertibleChangeTracking, System.IDisposable, Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService
+    {
+        protected static readonly object SyncRoot;
+        public ChangeTrackingService() { }
+        public bool CanRedo { get; }
+        public bool CanUndo { get; }
+        protected System.ComponentModel.EventHandlerList Events { get; }
+        public bool HasTransientEntities { get; }
+        public virtual bool IsChanged { get; }
+        public bool IsDisposed { get; }
+        public bool IsSuspended { get; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+        public System.ComponentModel.ISite Site { get; set; }
+        public event System.EventHandler<System.ComponentModel.CancelEventArgs> AcceptingChanges;
+        public event System.EventHandler ChangesAccepted;
+        public event System.EventHandler ChangesRejected;
+        public event System.EventHandler Disposed;
+        public event System.EventHandler<System.ComponentModel.CancelEventArgs> RejectingChanges;
+        public event System.EventHandler TrackingServiceStateChanged;
+        public virtual void AcceptChanges() { }
+        public virtual void Add(Topics.Radical.ComponentModel.ChangeTracking.IChange change, Topics.Radical.ComponentModel.ChangeTracking.AddChangeBehavior behavior) { }
+        public void Attach(Topics.Radical.ComponentModel.ChangeTracking.IMemento item) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.IAtomicOperation BeginAtomicOperation() { }
+        public virtual Topics.Radical.ComponentModel.ChangeTracking.IBookmark CreateBookmark() { }
+        public void Detach(Topics.Radical.ComponentModel.ChangeTracking.IMemento entity) { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        protected void EnsureNotSuspended() { }
+        protected override void Finalize() { }
+        public virtual Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GetAdvisory() { }
+        public virtual Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GetAdvisory(Topics.Radical.ComponentModel.ChangeTracking.IAdvisoryBuilder builder) { }
+        public virtual Topics.Radical.ComponentModel.ChangeTracking.IChangeSet GetChangeSet() { }
+        public virtual Topics.Radical.ComponentModel.ChangeTracking.IChangeSet GetChangeSet(Topics.Radical.ComponentModel.ChangeTracking.IChangeSetFilter filter) { }
+        public System.Collections.Generic.IEnumerable<object> GetEntities() { }
+        public virtual System.Collections.Generic.IEnumerable<object> GetEntities(Topics.Radical.ComponentModel.ChangeTracking.EntityTrackingStates stateFilter, bool exactMatch) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.EntityPropertyStates GetEntityPropertyState<TEntity, TProperty>(TEntity entity, System.Linq.Expressions.Expression<System.Func<TEntity, TProperty>> property) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.EntityPropertyStates GetEntityPropertyState<TEntity, TProperty>(TEntity entity, string propertyName) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.EntityTrackingStates GetEntityState(object entity) { }
+        protected virtual void OnAcceptingChanges(System.ComponentModel.CancelEventArgs e) { }
+        protected virtual void OnAttach(Topics.Radical.ComponentModel.ChangeTracking.IMemento item) { }
+        protected virtual void OnChangeCommitted(Topics.Radical.ComponentModel.ChangeTracking.IChange change, Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason) { }
+        protected virtual void OnChangeRejected(Topics.Radical.ComponentModel.ChangeTracking.IChange change, Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        protected virtual void OnChangesAccepted() { }
+        protected virtual void OnChangesRejected() { }
+        protected virtual void OnDetach(Topics.Radical.ComponentModel.ChangeTracking.IMemento entity, Topics.Radical.ChangeTracking.ChangeTrackingService.StopTrackingReason reason) { }
+        protected virtual void OnDisposed() { }
+        protected virtual void OnRedo(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        protected virtual void OnRegisterTransient(object entity, bool autoRemove) { }
+        protected virtual void OnRejectingChanges(System.ComponentModel.CancelEventArgs e) { }
+        protected virtual void OnRevert(Topics.Radical.ComponentModel.ChangeTracking.IBookmark bookmark) { }
+        protected virtual void OnTrackingServiceStateChanged() { }
+        protected virtual void OnUndo(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        protected virtual void OnUnregisterTransient(object entity) { }
+        protected virtual void OnUnwire(Topics.Radical.ComponentModel.ChangeTracking.IChange change) { }
+        protected virtual void OnWire(Topics.Radical.ComponentModel.ChangeTracking.IChange change) { }
+        protected virtual void OnWire(System.ComponentModel.IComponent entity) { }
+        public void Redo() { }
+        public void RegisterTransient(object entity) { }
+        public void RegisterTransient(object entity, bool autoRemove) { }
+        public virtual void RejectChanges() { }
+        public virtual void Resume() { }
+        public void Revert(Topics.Radical.ComponentModel.ChangeTracking.IBookmark bookmark) { }
+        public virtual void Suspend() { }
+        public void Undo() { }
+        public void UnregisterTransient(object entity) { }
+        public virtual bool Validate(Topics.Radical.ComponentModel.ChangeTracking.IBookmark bookmark) { }
+        protected enum StopTrackingReason
+        {
+            UserRequest = 0,
+            DisposedEvent = 1,
+        }
+    }
+    public class static ChangeTrackingServiceExtensions
+    {
+        public static T Attach<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service, T source) { }
+        public static System.Collections.Generic.IEnumerable<T> Attach<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service, System.Collections.Generic.IEnumerable<T> data) { }
+        public static System.Collections.Generic.IEnumerable<T> GetChangedItems<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service) { }
+        public static System.Collections.Generic.IEnumerable<T> GetDeletedItems<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service) { }
+        public static System.Collections.Generic.IEnumerable<T> GetNewItems<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service) { }
+        public static System.Collections.Generic.IEnumerable<T> GetRemovedItems<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service) { }
+    }
+    public sealed class IncludeAllChangeSetFilter : Topics.Radical.ComponentModel.ChangeTracking.IChangeSetFilter
+    {
+        public static Topics.Radical.ComponentModel.ChangeTracking.IChangeSetFilter Instance { get; }
+        public bool ShouldInclude(Topics.Radical.ComponentModel.ChangeTracking.IChange change) { }
+    }
+    public class static MementoExtensions
+    {
+        public static bool IsChanged(this Topics.Radical.ComponentModel.ChangeTracking.IMemento entity) { }
+        public static bool IsPropertyValueChanged<TEntity, TProperty>(this TEntity entity, System.Linq.Expressions.Expression<System.Func<TEntity, TProperty>> property)
+            where TEntity : Topics.Radical.ComponentModel.ChangeTracking.IMemento { }
+        public static bool IsTransient(this Topics.Radical.ComponentModel.ChangeTracking.IMemento entity) { }
+    }
+}
+namespace Topics.Radical.ChangeTracking.Specialized
+{
+    
+    public class AddRangeCollectionChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>, T>
+    
+    {
+        public AddRangeCollectionChange(object owner, Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public abstract class CollectionChange<TDescriptor, TItem> : Topics.Radical.ChangeTracking.Change<TDescriptor>, Topics.Radical.ComponentModel.ChangeTracking.IChange
+        where TDescriptor : Topics.Radical.ChangeTracking.Specialized.CollectionChangeDescriptor<>
+    
+    {
+        protected CollectionChange(object owner, TDescriptor descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<TDescriptor> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<TDescriptor> commitCallback, string description) { }
+        public TDescriptor Descriptor { get; }
+    }
+    public abstract class CollectionChangeDescriptor<T>
+    
+    {
+        protected CollectionChangeDescriptor() { }
+    }
+    public class CollectionClearedChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>, T>
+    
+    {
+        public CollectionClearedChange(object owner, Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public class CollectionRangeDescriptor<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChangeDescriptor<T>
+    
+    {
+        public CollectionRangeDescriptor(System.Collections.Generic.IEnumerable<T> items) { }
+        public System.Collections.Generic.IEnumerable<T> Items { get; }
+    }
+    public class ItemChangedCollectionChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>, T>
+    
+    {
+        public ItemChangedCollectionChange(object owner, Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public class ItemChangedDescriptor<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChangeDescriptor<T>
+    
+    {
+        public ItemChangedDescriptor(T item, int index) { }
+        public int Index { get; }
+        public T Item { get; }
+    }
+    public class ItemMovedCollectionChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.ItemMovedDescriptor<T>, T>
+    
+    {
+        public ItemMovedCollectionChange(object owner, Topics.Radical.ChangeTracking.Specialized.ItemMovedDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.ItemMovedDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.ItemMovedDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public class ItemMovedDescriptor<T> : Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>
+    
+    {
+        public ItemMovedDescriptor(T item, int newIndex, int oldIndex) { }
+        public int NewIndex { get; }
+        public int OldIndex { get; }
+    }
+    public class ItemRemovedCollectionChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>, T>
+    
+    {
+        public ItemRemovedCollectionChange(object owner, Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public class ItemReplacedCollectionChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.ItemReplacedDescriptor<T>, T>
+    
+    {
+        public ItemReplacedCollectionChange(object owner, Topics.Radical.ChangeTracking.Specialized.ItemReplacedDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.ItemReplacedDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.ItemReplacedDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public class ItemReplacedDescriptor<T> : Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>
+    
+    {
+        public ItemReplacedDescriptor(T newItem, T replacedItem, int index) { }
+        public T NewItem { get; }
+        public T ReplacedItem { get; }
+    }
+    public class PropertyValueChange<T> : Topics.Radical.ChangeTracking.Change<T>, Topics.Radical.ComponentModel.ChangeTracking.IChange, Topics.Radical.ComponentModel.ChangeTracking.IPropertyValueChange
+    
+    {
+        public PropertyValueChange(object owner, string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restoreCallback) { }
+        public PropertyValueChange(object owner, string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restoreCallback, string description) { }
+        public PropertyValueChange(object owner, string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restoreCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> commitCallback, string description) { }
+        public string PropertyName { get; }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+    }
+}
+namespace Topics.Radical.Collections
+{
+    
+    public class ReadOnlyCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable, Topics.Radical.ComponentModel.IReadOnlyCollection<T>
+    
+    {
+        public ReadOnlyCollection(System.Collections.Generic.IEnumerable<T> source) { }
+        public int Count { get; }
+        protected System.Collections.Generic.List<T> InnerList { get; }
+        public bool IsSynchronized { get; }
+        public object SyncRoot { get; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(T[] array, int index) { }
+        public System.Collections.IEnumerator GetEnumerator() { }
+    }
+}
+namespace Topics.Radical.ComponentModel
+{
+    
+    public sealed class ByteArrayTimestamp : Topics.Radical.ComponentModel.Timestamp<byte[]>
+    {
+        public static readonly Topics.Radical.ComponentModel.ByteArrayTimestamp Empty;
+        public ByteArrayTimestamp(byte[] value) { }
+        public override bool Equals(Topics.Radical.ComponentModel.Timestamp obj) { }
+        public override string ToString() { }
+    }
+    public class CollectionChangedEventArgs<T> : System.EventArgs
+    
+    {
+        public CollectionChangedEventArgs(Topics.Radical.ComponentModel.CollectionChangeType changeType) { }
+        public CollectionChangedEventArgs(Topics.Radical.ComponentModel.CollectionChangeType changeType, int index) { }
+        public CollectionChangedEventArgs(Topics.Radical.ComponentModel.CollectionChangeType changeType, int index, int oldIndex, T item) { }
+        public Topics.Radical.ComponentModel.CollectionChangeType ChangeType { get; }
+        public int Index { get; }
+        public T Item { get; }
+        public int OldIndex { get; }
+    }
+    public enum CollectionChangeType
+    {
+        None = 0,
+        SortChanged = 1,
+        ItemAdded = 2,
+        ItemRemoved = 3,
+        ItemChanged = 4,
+        Reset = 5,
+        ItemMoved = 6,
+        ItemReplaced = 7,
+    }
+    public class ComponentRegisteredEventArgs : System.EventArgs
+    {
+        public ComponentRegisteredEventArgs(Topics.Radical.ComponentModel.IContainerEntry entry) { }
+        public Topics.Radical.ComponentModel.IContainerEntry Entry { get; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    public sealed class ContractAttribute : System.Attribute
+    {
+        public ContractAttribute() { }
+        public ContractAttribute(System.Type contractInterface) { }
+        public System.Type ContractInterface { get; }
+    }
+    public class EntityItemViewCustomPropertyDescriptor<T, TValue> : Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T>
+    
+    
+    {
+        public EntityItemViewCustomPropertyDescriptor(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TValue> getter) { }
+        public EntityItemViewCustomPropertyDescriptor(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TValue> getter, Topics.Radical.ComponentModel.EntityItemViewValueSetter<T, TValue> setter) { }
+        public EntityItemViewCustomPropertyDescriptor(string customDisplayName) { }
+        public System.Func<TValue> DafaultValueInterceptor { get; set; }
+        public override string DisplayName { get; }
+        public override bool IsReadOnly { get; }
+        public override string Name { get; }
+        public override System.Type PropertyType { get; }
+        protected Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TValue> ValueGetter { get; }
+        protected Topics.Radical.ComponentModel.EntityItemViewValueSetter<T, TValue> ValueSetter { get; }
+        public TValue GetDefaultValue() { }
+        protected override object GetValueCore(Topics.Radical.ComponentModel.IEntityItemView<T> component) { }
+        protected override void SetValueCore(Topics.Radical.ComponentModel.IEntityItemView<T> component, object value) { }
+    }
+    public class EntityItemViewPropertyDescriptor<T> : System.ComponentModel.PropertyDescriptor
+    
+    {
+        protected EntityItemViewPropertyDescriptor() { }
+        public EntityItemViewPropertyDescriptor(System.Reflection.PropertyInfo property) { }
+        public EntityItemViewPropertyDescriptor(string propertyName) { }
+        public EntityItemViewPropertyDescriptor(string propertyName, string customDisplayName) { }
+        public override System.Type ComponentType { get; }
+        public override string DisplayName { get; }
+        public override bool IsReadOnly { get; }
+        protected System.Reflection.PropertyInfo Property { get; }
+        public override System.Type PropertyType { get; }
+        public override bool CanResetValue(object component) { }
+        public virtual object GetDefaultValue() { }
+        public virtual object GetValue(object component) { }
+        protected virtual object GetValueCore(Topics.Radical.ComponentModel.IEntityItemView<T> component) { }
+        public override void ResetValue(object component) { }
+        public virtual void SetValue(object component, object value) { }
+        protected virtual void SetValueCore(Topics.Radical.ComponentModel.IEntityItemView<T> component, object value) { }
+        public override bool ShouldSerializeValue(object component) { }
+    }
+    public abstract class EntityItemViewValueArgs<T, TValue>
+    
+    
+    {
+        protected EntityItemViewValueArgs(Topics.Radical.ComponentModel.IEntityItemView<T> item, string propertyName) { }
+        public Topics.Radical.ComponentModel.IEntityItemView<T> Item { get; }
+        public string PropertyName { get; }
+    }
+    public delegate object EntityItemViewValueGetter<T, TValue>(Topics.Radical.ComponentModel.EntityItemViewValueGetterArgs<T, TValue> args);
+    public class EntityItemViewValueGetterArgs<T, TValue> : Topics.Radical.ComponentModel.EntityItemViewValueArgs<T, TValue>
+    
+    
+    {
+        public EntityItemViewValueGetterArgs(Topics.Radical.ComponentModel.IEntityItemView<T> item, string propertyName) { }
+    }
+    public delegate void EntityItemViewValueSetter<T, TValue>(Topics.Radical.ComponentModel.EntityItemViewValueSetterArgs<T, TValue> args);
+    public class EntityItemViewValueSetterArgs<T, TValue> : Topics.Radical.ComponentModel.EntityItemViewValueArgs<T, TValue>
+    
+    
+    {
+        public EntityItemViewValueSetterArgs(Topics.Radical.ComponentModel.IEntityItemView<T> item, string propertyName, TValue value) { }
+        public TValue Value { get; }
+    }
+    public interface IAnalyticsServices
+    {
+        bool IsEnabled { get; set; }
+        void TrackUserActionAsync(Topics.Radical.Analytics.AnalyticsEvent action);
+    }
+    public interface IBootable
+    {
+        void Boot();
+    }
+    public interface IContainerEntry
+    {
+        System.Type Component { get; }
+        System.Delegate Factory { get; }
+        bool IsOverridable { get; }
+        string Key { get; }
+        Topics.Radical.ComponentModel.Lifestyle Lifestyle { get; }
+        System.Collections.Generic.IDictionary<string, object> Parameters { get; }
+        System.Collections.Generic.IEnumerable<System.Type> Services { get; }
+    }
+    [Topics.Radical.ComponentModel.ContractAttribute()]
+    public interface IDataContext : System.IDisposable
+    {
+        bool HasPendingChanges { get; }
+        Topics.Radical.ComponentModel.ITransaction Transaction { get; }
+        Topics.Radical.ComponentModel.ITransaction BeginTransaction();
+        Topics.Radical.ComponentModel.ITransaction BeginTransaction(System.Data.IsolationLevel isolationLevel);
+        void Clear();
+        void Delete(object entity);
+        void Detach(object entity);
+        int Execute<TCommand>(TCommand command)
+            where TCommand : Topics.Radical.ComponentModel.QueryModel.IBatchCommand;
+        void FlushChanges();
+        T GetByKey<T>(object key);
+        System.Collections.Generic.IList<TResult> GetByQuery<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec);
+        System.Collections.Generic.IEnumerable<TResult> GetBySpecification<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult> specification);
+        TResult GetScalar<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec);
+        void Insert(object entity);
+        bool IsAttached(object entity);
+        void Save(object entity);
+        void Update(object entity);
+    }
+    public interface IDataContextFactoryProvider
+    {
+        Topics.Radical.ComponentModel.Factories.IDataContextFactory GetDefaultInstance();
+        Topics.Radical.ComponentModel.Factories.IDataContextFactory GetInstance(string name);
+    }
+    public interface IDispatcher
+    {
+        bool IsSafe { get; }
+        void Dispatch(System.Action action);
+        void Dispatch<T>(T arg, System.Action<T> action);
+        void Dispatch<T1, T2>(T1 arg1, T2 arg2, System.Action<T1, T2> action);
+        TResult Dispatch<TResult>(System.Func<TResult> func);
+        void Invoke(System.Delegate d, params object[] args);
+    }
+    public interface IEntityCollection<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.IEnumerable, System.ComponentModel.ISupportInitialize
+    
+    {
+        bool AllowNew { get; }
+        Topics.Radical.ComponentModel.IEntityView<T> DefaultView { get; }
+        bool IsInitializing { get; }
+        public event System.EventHandler<Topics.Radical.ComponentModel.CollectionChangedEventArgs<T>> CollectionChanged;
+        void AddRange(System.Collections.Generic.IEnumerable<T> list);
+        T CreateNew();
+        Topics.Radical.ComponentModel.IEntityView<T> CreateView();
+        void EndInit(bool notify);
+        void Move(int oldIndex, int newIndex);
+        void Move(T item, int newIndex);
+        T[] ToArray();
+    }
+    public interface IEntityItemView : System.ComponentModel.ICustomTypeDescriptor, System.ComponentModel.IEditableObject, System.ComponentModel.INotifyPropertyChanged, Topics.Radical.ComponentModel.INotifyEditableObject
+    {
+        object EntityItem { get; }
+        Topics.Radical.ComponentModel.IEntityView View { get; }
+        void Delete();
+        TValue GetCustomValue<TValue>(string customPropertyName);
+        void NotifyPropertyChanged(string propertyName);
+        void SetCustomValue<TValue>(string customPropertyName, TValue value);
+    }
+    public interface IEntityItemView<T> : System.ComponentModel.ICustomTypeDescriptor, System.ComponentModel.IEditableObject, System.ComponentModel.INotifyPropertyChanged, Topics.Radical.ComponentModel.IEntityItemView, Topics.Radical.ComponentModel.INotifyEditableObject
+    
+    {
+        T EntityItem { get; }
+        Topics.Radical.ComponentModel.IEntityView<T> View { get; }
+    }
+    public interface IEntityItemViewFilter
+    {
+        bool ShouldInclude(object item);
+    }
+    public interface IEntityItemViewFilter<T> : Topics.Radical.ComponentModel.IEntityItemViewFilter
+    
+    {
+        bool ShouldInclude(T item);
+    }
+    public interface IEntityView : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IBindingList, System.ComponentModel.IBindingListView, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.ISupportInitialize, System.ComponentModel.ITypedList
+    {
+        bool AllowMove { get; }
+        System.Collections.IList DataSource { get; }
+        Topics.Radical.ComponentModel.IEntityItemViewFilter Filter { get; set; }
+        bool IsAddingNew { get; }
+        bool IsArrayBased { get; }
+        bool IsFiltered { get; }
+        public event System.EventHandler FilterChanged;
+        public event System.EventHandler SortChanged;
+        void ApplySort(string sortDescriptions);
+        void CancelNew();
+        void CancelNew(int itemIndex);
+        void EndNew();
+        void EndNew(int itemIndex);
+        void Move(int sourceIndex, int newIndex);
+        void Refresh();
+    }
+    public interface IEntityView<T> : System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IEntityItemView<T>>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IBindingList, System.ComponentModel.IBindingListView, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.ISupportInitialize, System.ComponentModel.ITypedList, Topics.Radical.ComponentModel.IEntityView
+    
+    {
+        bool AutoGenerateProperties { get; set; }
+        Topics.Radical.ComponentModel.IEntityItemViewFilter<T> Filter { get; set; }
+        public event System.EventHandler<Topics.Radical.Model.AddingNewEventArgs<T>> AddingNew;
+        Topics.Radical.ComponentModel.IEntityItemView<T> AddNew();
+        Topics.Radical.ComponentModel.IEntityItemView<T> AddNew(System.Action<Topics.Radical.Model.AddingNewEventArgs<T>> addNewInterceptor);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string calculatedPropertyDisplayName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter, Topics.Radical.ComponentModel.EntityItemViewValueSetter<T, TProperty> setter);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string calculatedPropertyDisplayName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string calculatedPropertyDisplayName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter, System.Func<TProperty> defaultValueInterceptor);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(string propertyName, string displayName);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> customProperty);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(string propertyName);
+        void ApplyFilter(System.Predicate<T> predicate);
+        void ApplySort(System.Collections.Generic.IComparer<Topics.Radical.ComponentModel.IEntityItemView<T>> comparer);
+        System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T>> GetCustomProperties();
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> GetCustomProperty(string name);
+        TValue GetCustomPropertyValue<TValue>(string customPropertyName, Topics.Radical.ComponentModel.IEntityItemView<T> item);
+        System.ComponentModel.PropertyDescriptor GetProperty(string name);
+        bool IsPropertyMappingDefined(string propertyName);
+        void Move(Topics.Radical.ComponentModel.IEntityItemView<T> item, int newIndex);
+        bool RemovePropertyMapping(Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> customProperty);
+        bool RemovePropertyMapping(string propertyName);
+        void SetCustomPropertyValue<TValue>(string customPropertyName, Topics.Radical.ComponentModel.IEntityItemView<T> item, TValue value);
+    }
+    public interface IHaveTimestamp<T>
+    
+    {
+        Topics.Radical.ComponentModel.Timestamp<T> Timestamp { get; set; }
+    }
+    public interface IKey : System.IComparable, System.IEquatable<Topics.Radical.ComponentModel.IKey>
+    {
+        bool IsEmpty { get; }
+    }
+    public interface IKey<T> : System.IComparable, System.IComparable<Topics.Radical.ComponentModel.IKey<T>>, System.IEquatable<Topics.Radical.ComponentModel.IKey<T>>, System.IEquatable<Topics.Radical.ComponentModel.IKey>, Topics.Radical.ComponentModel.IKey
+        where T : System.IComparable, System.IComparable<>
+    {
+        T Value { get; }
+    }
+    public interface IKeyService
+    {
+        Topics.Radical.ComponentModel.IKey GenerateEmpty();
+    }
+    public interface IMonitor
+    {
+        public event System.EventHandler Changed;
+        void NotifyChanged();
+        void StopMonitoring();
+    }
+    public interface IMonitor<T> : Topics.Radical.ComponentModel.IMonitor
+    
+    {
+        T Source { get; }
+    }
+    public interface INotifyEditableObject : System.ComponentModel.IEditableObject
+    {
+        public event System.EventHandler EditBegun;
+        public event System.EventHandler EditCanceled;
+        public event System.EventHandler EditEnded;
+    }
+    public interface IPuzzleContainer : System.IDisposable
+    {
+        public event System.EventHandler<Topics.Radical.ComponentModel.ComponentRegisteredEventArgs> ComponentRegistered;
+        Topics.Radical.ComponentModel.IPuzzleContainer AddFacility(Topics.Radical.ComponentModel.IPuzzleContainerFacility facility);
+        Topics.Radical.ComponentModel.IPuzzleContainer AddFacility<TFacility>()
+            where TFacility : Topics.Radical.ComponentModel.IPuzzleContainerFacility;
+        bool IsRegistered<TService>();
+        bool IsRegistered(System.Type serviceType);
+        Topics.Radical.ComponentModel.IPuzzleContainer Register(System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IContainerEntry> entries);
+        Topics.Radical.ComponentModel.IPuzzleContainer Register(Topics.Radical.ComponentModel.IContainerEntry entry);
+        object Resolve(System.Type serviceType);
+        object Resolve(string key, System.Type serviceType);
+        TService Resolve<TService>();
+        System.Collections.Generic.IEnumerable<T> ResolveAll<T>();
+        System.Collections.Generic.IEnumerable<object> ResolveAll(System.Type t);
+        void SetupWith(System.Func<System.Collections.Generic.IEnumerable<System.Type>> knownTypesProvider, params Topics.Radical.ComponentModel.IPuzzleSetupDescriptor[] descriptors);
+    }
+    public interface IPuzzleContainerEntry : Topics.Radical.ComponentModel.IContainerEntry
+    {
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry Forward(System.Type forwardedType);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry ImplementedBy(System.Type componentType);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry Overridable();
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry UsingFactory(System.Func<object> factory);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry UsingInstance(object instance);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry WithLifestyle(Topics.Radical.ComponentModel.Lifestyle lifestyle);
+    }
+    public interface IPuzzleContainerEntry<T> : Topics.Radical.ComponentModel.IContainerEntry
+    
+    {
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> Forward<TForwarded>();
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> ImplementedBy(System.Type componentType);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> ImplementedBy<TComponent>()
+            where TComponent : T;
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> Overridable();
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> UsingFactory(System.Func<T> factory);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> UsingInstance<TComponent>(TComponent instance)
+            where TComponent : T;
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> WithLifestyle(Topics.Radical.ComponentModel.Lifestyle lifestyle);
+    }
+    public interface IPuzzleContainerFacility
+    {
+        void Initialize(Topics.Radical.ComponentModel.IPuzzleContainer container);
+        void Teardown(Topics.Radical.ComponentModel.IPuzzleContainer container);
+    }
+    public interface IPuzzleSetupDescriptor
+    {
+        void Setup(Topics.Radical.ComponentModel.IPuzzleContainer container, System.Func<System.Collections.Generic.IEnumerable<System.Type>> knownTypesProvider);
+    }
+    public interface IReadOnlyCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable { }
+    public interface ITransaction : System.IDisposable
+    {
+        void Commit();
+        void Rollback();
+    }
+    public interface IUniqueEntity
+    {
+        Topics.Radical.ComponentModel.IKey Key { get; }
+    }
+    public interface IUniqueEntity<T> : Topics.Radical.ComponentModel.IUniqueEntity
+        where T : System.IComparable, System.IComparable<>
+    {
+        Topics.Radical.ComponentModel.IKey<T> Key { get; }
+    }
+    public enum Lifestyle
+    {
+        Singleton = 0,
+        Transient = 1,
+    }
+    public abstract class Timestamp
+    {
+        protected Timestamp() { }
+        public abstract bool Equals(Topics.Radical.ComponentModel.Timestamp obj);
+        public virtual bool Equals(object obj) { }
+        public virtual int GetHashCode() { }
+    }
+    public class Timestamp<T> : Topics.Radical.ComponentModel.Timestamp
+    
+    {
+        public Timestamp(T value) { }
+        public T Value { get; }
+        public override bool Equals(Topics.Radical.ComponentModel.Timestamp obj) { }
+        public override int GetHashCode() { }
+    }
+}
+namespace Topics.Radical.ComponentModel.ChangeTracking
+{
+    
+    public enum AddChangeBehavior
+    {
+        None = 0,
+        Default = 1,
+        RedoRequest = 2,
+        UndoRequest = 3,
+    }
+    public class ChangeCommittedEventArgs<T> : Topics.Radical.ComponentModel.ChangeTracking.ChangeEventArgs<T>
+    
+    {
+        public ChangeCommittedEventArgs(object entity, T cachedValue, Topics.Radical.ComponentModel.ChangeTracking.IChange source, Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.CommitReason Reason { get; }
+    }
+    public class ChangeEventArgs<T> : System.EventArgs
+    
+    {
+        public ChangeEventArgs(object entity, T cachedValue, Topics.Radical.ComponentModel.ChangeTracking.IChange source) { }
+        public T CachedValue { get; }
+        public object Entity { get; }
+        public Topics.Radical.ComponentModel.ChangeTracking.IChange Source { get; }
+    }
+    public class ChangeRejectedEventArgs<T> : Topics.Radical.ComponentModel.ChangeTracking.ChangeEventArgs<T>
+    
+    {
+        public ChangeRejectedEventArgs(object entity, T cachedValue, Topics.Radical.ComponentModel.ChangeTracking.IChange source, Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.RejectReason Reason { get; }
+    }
+    public enum ChangeTrackingRegistration
+    {
+        AsTransient = 0,
+        AsPersistent = 1,
+    }
+    public delegate void CommitCallback<T>(Topics.Radical.ComponentModel.ChangeTracking.ChangeCommittedEventArgs<T> value);
+    public enum CommitReason
+    {
+        None = 0,
+        AcceptChanges = 1,
+    }
+    public class CommittedEventArgs : System.EventArgs
+    {
+        public CommittedEventArgs(Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.CommitReason Reason { get; }
+    }
+    [System.FlagsAttribute()]
+    public enum EntityPropertyStates
+    {
+        None = 0,
+        Changed = 1,
+        ValueChanged = 2,
+    }
+    [System.FlagsAttribute()]
+    public enum EntityTrackingStates
+    {
+        None = 0,
+        IsTransient = 1,
+        AutoRemove = 2,
+        HasBackwardChanges = 4,
+        HasForwardChanges = 8,
+    }
+    public interface IAdvisedAction
+    {
+        Topics.Radical.ComponentModel.ChangeTracking.ProposedActions Action { get; }
+        object Target { get; }
+    }
+    public interface IAdvisory : System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction>, System.Collections.ICollection, System.Collections.IEnumerable, Topics.Radical.ComponentModel.IReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction> { }
+    public interface IAdvisoryBuilder
+    {
+        Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GenerateAdvisory(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService svc, Topics.Radical.ComponentModel.ChangeTracking.IChangeSet changeSet);
+    }
+    public interface IAtomicOperation : System.IDisposable
+    {
+        void Complete();
+    }
+    public interface IBookmark
+    {
+        Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Owner { get; }
+        Topics.Radical.ComponentModel.ChangeTracking.IChange Position { get; }
+        System.Collections.Generic.IEnumerable<object> TransientEntities { get; }
+    }
+    public interface IChange
+    {
+        string Description { get; }
+        bool IsCommitSupported { get; }
+        object Owner { get; }
+        public event System.EventHandler<Topics.Radical.ComponentModel.ChangeTracking.CommittedEventArgs> Committed;
+        public event System.EventHandler<Topics.Radical.ComponentModel.ChangeTracking.RejectedEventArgs> Rejected;
+        Topics.Radical.ComponentModel.ChangeTracking.IChange Clone();
+        void Commit(Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason);
+        Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem);
+        System.Collections.Generic.IEnumerable<object> GetChangedEntities();
+        void Reject(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason);
+    }
+    public interface IChange<T> : Topics.Radical.ComponentModel.ChangeTracking.IChange
+    
+    {
+        T CachedValue { get; }
+    }
+    public interface IChangeSet : System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IChange>, System.Collections.ICollection, System.Collections.IEnumerable, Topics.Radical.ComponentModel.IReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IChange> { }
+    public interface IChangeSetDistinctVisitor
+    {
+        System.Collections.Generic.IDictionary<object, Topics.Radical.ComponentModel.ChangeTracking.IChange> Visit(Topics.Radical.ComponentModel.ChangeTracking.IChangeSet changeSet);
+    }
+    public interface IChangeSetFilter
+    {
+        bool ShouldInclude(Topics.Radical.ComponentModel.ChangeTracking.IChange change);
+    }
+    public interface IChangeTrackingService : System.ComponentModel.IChangeTracking, System.ComponentModel.IComponent, System.ComponentModel.IRevertibleChangeTracking, System.IDisposable
+    {
+        bool CanRedo { get; }
+        bool CanUndo { get; }
+        bool HasTransientEntities { get; }
+        bool IsDisposed { get; }
+        bool IsSuspended { get; }
+        public event System.EventHandler<System.ComponentModel.CancelEventArgs> AcceptingChanges;
+        public event System.EventHandler ChangesAccepted;
+        public event System.EventHandler ChangesRejected;
+        public event System.EventHandler<System.ComponentModel.CancelEventArgs> RejectingChanges;
+        public event System.EventHandler TrackingServiceStateChanged;
+        void Add(Topics.Radical.ComponentModel.ChangeTracking.IChange change, Topics.Radical.ComponentModel.ChangeTracking.AddChangeBehavior behavior);
+        void Attach(Topics.Radical.ComponentModel.ChangeTracking.IMemento item);
+        Topics.Radical.ComponentModel.ChangeTracking.IAtomicOperation BeginAtomicOperation();
+        Topics.Radical.ComponentModel.ChangeTracking.IBookmark CreateBookmark();
+        void Detach(Topics.Radical.ComponentModel.ChangeTracking.IMemento entity);
+        Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GetAdvisory();
+        Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GetAdvisory(Topics.Radical.ComponentModel.ChangeTracking.IAdvisoryBuilder builder);
+        Topics.Radical.ComponentModel.ChangeTracking.IChangeSet GetChangeSet();
+        Topics.Radical.ComponentModel.ChangeTracking.IChangeSet GetChangeSet(Topics.Radical.ComponentModel.ChangeTracking.IChangeSetFilter builder);
+        System.Collections.Generic.IEnumerable<object> GetEntities();
+        System.Collections.Generic.IEnumerable<object> GetEntities(Topics.Radical.ComponentModel.ChangeTracking.EntityTrackingStates sateFilter, bool exactMatch);
+        Topics.Radical.ComponentModel.ChangeTracking.EntityPropertyStates GetEntityPropertyState<TEntity, TProperty>(TEntity entity, System.Linq.Expressions.Expression<System.Func<TEntity, TProperty>> property);
+        Topics.Radical.ComponentModel.ChangeTracking.EntityPropertyStates GetEntityPropertyState<TEntity, TProperty>(TEntity entity, string propertyName);
+        Topics.Radical.ComponentModel.ChangeTracking.EntityTrackingStates GetEntityState(object entity);
+        void Redo();
+        void RegisterTransient(object entity);
+        void RegisterTransient(object entity, bool autoRemove);
+        void Resume();
+        void Revert(Topics.Radical.ComponentModel.ChangeTracking.IBookmark bookmark);
+        void Suspend();
+        void Undo();
+        void UnregisterTransient(object entity);
+        bool Validate(Topics.Radical.ComponentModel.ChangeTracking.IBookmark bookmark);
+    }
+    public interface IMemento
+    {
+        Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Memento { get; set; }
+    }
+    public interface IMementoPropertyMetadata
+    {
+        bool TrackChanges { get; set; }
+    }
+    public interface IPropertyValueChange : Topics.Radical.ComponentModel.ChangeTracking.IChange
+    {
+        string PropertyName { get; }
+    }
+    [System.FlagsAttribute()]
+    public enum ProposedActions
+    {
+        None = 0,
+        Create = 1,
+        Update = 2,
+        Delete = 4,
+        Dispose = 8,
+    }
+    public delegate void RejectCallback<T>(Topics.Radical.ComponentModel.ChangeTracking.ChangeRejectedEventArgs<T> value);
+    public class RejectedEventArgs : System.EventArgs
+    {
+        public RejectedEventArgs(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.RejectReason Reason { get; }
+    }
+    public enum RejectReason
+    {
+        None = 0,
+        Undo = 1,
+        Redo = 2,
+        RejectChanges = 3,
+        Revert = 4,
+    }
+    public enum TransientRegistration
+    {
+        AsTransparent = 0,
+        AsPersistable = 1,
+    }
+}
+namespace Topics.Radical.ComponentModel.Factories
+{
+    
+    public interface IChangeTrackingServiceFactory
+    {
+        Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Create();
+    }
+    [Topics.Radical.ComponentModel.ContractAttribute()]
+    public interface IDataContextFactory
+    {
+        Topics.Radical.ComponentModel.IDataContext Create();
+    }
+    public interface IEntityFactory
+    {
+        T Create<T>(params object[] constructorArguments);
+        object Create(System.Type type, params object[] constructorArguments);
+    }
+}
+namespace Topics.Radical.ComponentModel.Messaging
+{
+    
+    public interface IHandleMessage
+    {
+        void Handle(object sender, object message);
+        bool ShouldHandle(object sender, object message);
+    }
+    [Topics.Radical.ComponentModel.ContractAttribute()]
+    public interface IHandleMessage<T> : Topics.Radical.ComponentModel.Messaging.IHandleMessage
+    
+    {
+        void Handle(object sender, T message);
+    }
+    public interface ILegacyMessageCompatibility
+    {
+        void SetSenderForBackwardCompatibility(object sender);
+    }
+    [System.ObsoleteAttribute("The Radical message broker now supports POCO messages, will be removed in the nex" +
+        "t version.", false)]
+    public interface IMessage : Topics.Radical.ComponentModel.Messaging.ILegacyMessageCompatibility
+    {
+        object Sender { get; }
+    }
+    public interface IMessageBroker
+    {
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Broadcast<T>(T message)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        void Broadcast(object sender, object message);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Broadcast(System.Type messageType, Topics.Radical.ComponentModel.Messaging.IMessage message);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Dispatch(Topics.Radical.ComponentModel.Messaging.IMessage message);
+        void Dispatch(object sender, object message);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Dispatch<T>(T message)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Dispatch(System.Type messageType, Topics.Radical.ComponentModel.Messaging.IMessage message);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe<T>(object subscriber, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe(object subscriber, System.Type messageType, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe(object subscriber, object sender, System.Type messageType, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe<T>(object subscriber, object sender, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        void Subscribe(object subscriber, object sender, System.Type messageType, System.Action<object, object> callback);
+        void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, object> callback);
+        void Subscribe(object subscriber, System.Type messageType, System.Action<object, object> callback);
+        void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, object> callback);
+        void Subscribe<T>(object subscriber, System.Action<object, T> callback);
+        void Subscribe(object subscriber, object sender, System.Type messageType, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback);
+        void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback);
+        void Subscribe(object subscriber, System.Type messageType, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback);
+        void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback);
+        void Subscribe<T>(object subscriber, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, object sender, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, object sender, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback);
+        void Unsubscribe(object subscriber);
+        void Unsubscribe<T>(object subscriber);
+        void Unsubscribe(object subscriber, object sender);
+        void Unsubscribe<T>(object subscriber, object sender);
+        void Unsubscribe<T>(object subscriber, System.Delegate callback);
+    }
+    [System.ObsoleteAttribute("The Radical message broker now supports POCO messages.", false)]
+    public interface IMessageHandler
+    {
+        void Handle(Topics.Radical.ComponentModel.Messaging.IMessage message);
+        bool ShouldHandle(Topics.Radical.ComponentModel.Messaging.IMessage message);
+    }
+    [System.ObsoleteAttribute("The Radical message broker now supports POCO messages.", false)]
+    [Topics.Radical.ComponentModel.ContractAttribute()]
+    public interface IMessageHandler<T> : Topics.Radical.ComponentModel.Messaging.IMessageHandler
+        where T : Topics.Radical.ComponentModel.Messaging.IMessage
+    {
+        void Handle(T message);
+    }
+    public interface INeedSafeSubscription { }
+    public enum InvocationModel
+    {
+        Default = 0,
+        Safe = 1,
+    }
+    public interface IRequireToBeValid
+    {
+        void Validate();
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.All, AllowMultiple=true)]
+    [System.ObsoleteAttribute("Not required anymore, will be removed in the version.", false)]
+    public sealed class SubscribeToMessageAttribute : System.Attribute
+    {
+        public SubscribeToMessageAttribute(System.Type messageType) { }
+        public System.Type MessageType { get; }
+    }
+}
+namespace Topics.Radical.ComponentModel.QueryModel
+{
+    
+    public interface IBatchCommand { }
+    public interface IBatchCommandEngine<TCommand, TProvider>
+        where TCommand : Topics.Radical.ComponentModel.QueryModel.IBatchCommand
+    
+    {
+        int Execute(TCommand command, TProvider provider);
+    }
+    public interface IQueryEngine<TSource, TResult, TProvider>
+    
+    
+    
+    {
+        System.Collections.Generic.IList<TResult> ExecuteQuery(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+    }
+    public interface IQueryEngine<TQuery, TSource, TResult, TProvider> : Topics.Radical.ComponentModel.QueryModel.IQueryEngine<TSource, TResult, TProvider>
+        where TQuery : Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<, >
+    
+    
+    
+    {
+        System.Collections.Generic.IList<TResult> ExecuteQuery(TQuery querySpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+    }
+    public interface IQuerySpecification<T> : Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<T, T>, Topics.Radical.ComponentModel.QueryModel.ISpecification<T, T> { }
+    public interface IQuerySpecification<TSource, TResult> : Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult> { }
+    public interface IQuerySystemManager
+    {
+        Topics.Radical.ComponentModel.QueryModel.IBatchCommandEngine<TCommand, TProvider> GetBatchCommandEngine<TCommand, TProvider>(TCommand command)
+            where TCommand : Topics.Radical.ComponentModel.QueryModel.IBatchCommand
+        ;
+        Topics.Radical.ComponentModel.QueryModel.IQueryEngine<TSource, TResult, TProvider> GetQueryEngine<TSource, TResult, TProvider>(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec);
+        Topics.Radical.ComponentModel.QueryModel.IScalarEvaluator<TSource, TResult, TProvider> GetScalarEvaluator<TSource, TResult, TProvider>(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec);
+    }
+    public interface IScalarEvaluator<TSource, TResult, TProvider>
+    
+    
+    
+    {
+        TResult Evaluate(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+    }
+    public interface IScalarEvaluator<TScalar, TSource, TResult, TProvider> : Topics.Radical.ComponentModel.QueryModel.IScalarEvaluator<TSource, TResult, TProvider>
+        where TScalar : Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<, >
+    
+    
+    
+    {
+        TResult Evaluate(TScalar scalarSpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+    }
+    public interface IScalarSpecification<T> : Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<T, T>, Topics.Radical.ComponentModel.QueryModel.ISpecification<T, T> { }
+    public interface IScalarSpecification<TSource, TResult> : Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult> { }
+    public interface ISpecification<TSource, TResult> { }
+    public class SpecificationNotSupportedException : System.Exception
+    {
+        public SpecificationNotSupportedException() { }
+        public SpecificationNotSupportedException(string message) { }
+        public SpecificationNotSupportedException(string message, System.Exception inner) { }
+        protected SpecificationNotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+}
+namespace Topics.Radical.ComponentModel.Validation
+{
+    
+    public interface IRequireValidationCallback<T>
+    
+    {
+        void OnValidate(Topics.Radical.Validation.ValidationContext<T> context);
+    }
+    public interface IValidator
+    {
+        string RuleSet { get; }
+        bool IsValid(object entity);
+        Topics.Radical.Validation.ValidationResults Validate(object entity);
+        Topics.Radical.Validation.ValidationResults Validate(object entity, string propertyName);
+    }
+    [Topics.Radical.ComponentModel.ContractAttribute()]
+    public interface IValidator<T> : Topics.Radical.ComponentModel.Validation.IValidator
+    
+    {
+        new string RuleSet { get; }
+        Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Action<Topics.Radical.Validation.ValidationContext<T>> rule);
+        Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Linq.Expressions.Expression<System.Func<T, object>> propertyIdentifier, System.Func<Topics.Radical.Validation.ValidationContext<T>, Topics.Radical.ComponentModel.Validation.RuleEvaluation> rule, string error);
+        Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Linq.Expressions.Expression<System.Func<T, object>> propertyIdentifier, System.Func<Topics.Radical.Validation.ValidationContext<T>, Topics.Radical.ComponentModel.Validation.RuleEvaluation> rule, System.Func<Topics.Radical.Validation.ValidationContext<T>, string> error);
+        bool IsValid(T entity);
+        Topics.Radical.Validation.ValidationResults Validate(T entity);
+        Topics.Radical.Validation.ValidationResults Validate(T entity, string propertyName);
+        Topics.Radical.Validation.ValidationResults Validate<TProperty>(T entity, System.Linq.Expressions.Expression<System.Func<T, TProperty>> property);
+    }
+    public interface IValidatorFactory
+    {
+        Topics.Radical.ComponentModel.Validation.IValidator<T> CreateValidator<T>();
+        Topics.Radical.ComponentModel.Validation.IValidator<T> CreateValidator<T>(string ruleSet);
+    }
+    public enum RuleEvaluation
+    {
+        Succeeded = 0,
+        Failed = 1,
+    }
+}
+namespace Topics.Radical.Conversions
+{
+    
+    public class static CastExtensions
+    {
+        public static TResult As<TResult>(this object obj)
+            where TResult :  class { }
+        public static TResult As<TResult>(this object obj, System.Action invalidCastAction)
+            where TResult :  class { }
+        public static TResult As<TResult>(this object obj, System.Action<TResult> validCastAction)
+            where TResult :  class { }
+        public static TResult As<TResult>(this object obj, System.Action<TResult> validCastAction, System.Action invalidCastAction)
+            where TResult :  class { }
+        public static TResult CastTo<TResult>(this object obj) { }
+    }
+    public class static ConvertExtensions
+    {
+        public static Topics.Radical.Observable<T> AsObservable<T>(this T value) { }
+        [System.ObsoleteAttribute()]
+        public static bool ToBoolean(this string value) { }
+        [System.ObsoleteAttribute()]
+        public static decimal ToDecimal(this string value) { }
+        [System.ObsoleteAttribute()]
+        public static decimal ToDecimal(this double value) { }
+        [System.ObsoleteAttribute()]
+        public static int ToInt32(this string value) { }
+    }
+    public class static KeyConversionExtensions
+    {
+        public static Topics.Radical.ComponentModel.IKey<T> AsKey<T>(this T value)
+            where T : System.IComparable, System.IComparable<> { }
+        public static T AsValue<T>(this Topics.Radical.ComponentModel.IKey value)
+            where T : System.IComparable, System.IComparable<> { }
+    }
+}
+namespace Topics.Radical.Data.Adapters
+{
+    
+    public abstract class DataAdapter<TSource, TDestination> : Topics.Radical.Data.Adapters.IDataAdapter<TSource, TDestination>
+    
+    
+    {
+        protected DataAdapter() { }
+        public abstract TDestination Adapt(TSource source);
+        public virtual void Invalidate() { }
+    }
+    public abstract class DataFiller<TSource, TDestination> : Topics.Radical.Data.Adapters.IDataFiller<TSource, TDestination>
+    
+    
+    {
+        protected DataFiller() { }
+        public abstract TDestination Fill(TSource source, TDestination destination);
+        public virtual void Invalidate() { }
+    }
+    public interface IDataAdapter<TSource, TDestination>
+    
+    
+    {
+        TDestination Adapt(TSource source);
+        void Invalidate();
+    }
+    public interface IDataFiller<TSource, TDestination>
+    
+    
+    {
+        TDestination Fill(TSource source, TDestination destination);
+        void Invalidate();
+    }
+}
+namespace Topics.Radical.Data
+{
+    
+    public class DataBase : Topics.Radical.Data.IDataBase
+    {
+        public DataBase(string providerName, string connectionString) { }
+        public DataBase(string providerName, string connectionString, System.Data.CommandType defaultCommandType) { }
+        public DataBase(System.Data.Common.DbConnection connection) { }
+        public DataBase(System.Data.Common.DbConnection connection, System.Data.CommandType defaultCommandType) { }
+        public virtual Topics.Radical.Data.IDataBase AddParameter(System.Data.IDataParameter parameter) { }
+        public virtual Topics.Radical.Data.IDataBase AddParameterRange(System.Collections.Generic.IEnumerable<System.Data.IDataParameter> range) { }
+        public virtual Topics.Radical.Data.IDataBase AddParameterRange(System.Data.IDataParameterCollection range) { }
+        public virtual Topics.Radical.Data.IDataBase As(System.Data.CommandType commandType) { }
+        protected virtual System.Data.IDbCommand CreateCommand(System.Data.IDbConnection connection) { }
+        public virtual int ExecuteNonQuery() { }
+        public T ExecuteReader<T>()
+            where T :  class, System.Data.IDataReader { }
+        public virtual System.Data.IDataReader ExecuteReader() { }
+        public virtual object ExecuteScalar() { }
+        public T ExecuteScalar<T>() { }
+        protected virtual System.Data.IDbConnection GetConnection() { }
+        public virtual Topics.Radical.Data.IDataBase UseCommand(string commandText) { }
+    }
+    [System.ObsoleteAttribute("Use DataBase instead.")]
+    public abstract class DataCommand : System.IDisposable, Topics.Radical.Data.IDataCommand
+    {
+        protected DataCommand(string connString, string cmdText, System.Data.CommandType cmdType) { }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public string CommandText { get; }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public System.Data.CommandType CommandType { get; }
+        protected string ConnectionString { get; }
+        protected System.Collections.Generic.IList<System.Data.IDataParameter> Parameters { get; }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public int ExecuteNonQuery() { }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public int ExecuteNonQuery(string commandText) { }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public object ExecuteScalar() { }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public object ExecuteScalar(string commandText) { }
+        protected override void Finalize() { }
+        protected virtual Topics.Radical.Data.IDataCommand OnAddParameter(System.Data.IDataParameter parameter) { }
+        protected virtual Topics.Radical.Data.IDataCommand OnAddParameterRange(System.Collections.Generic.IEnumerable<System.Data.IDataParameter> range) { }
+        protected Topics.Radical.Data.IDataCommand OnCommand(string commandText) { }
+        protected abstract System.Data.IDbCommand OnCreateCommand(System.Data.IDbConnection connection);
+        protected virtual void OnDisposeConnection(System.Data.IDbConnection connection) { }
+        protected virtual int OnExecuteNonQuery(string commandText) { }
+        protected System.Data.IDataReader OnExecuteReader(string commandText) { }
+        protected object OnExecuteScalar(string commandText) { }
+        protected abstract System.Data.IDbConnection OnGetConnection(ref bool shouldDisposeConnectio);
+        protected Topics.Radical.Data.IDataCommand OnType(System.Data.CommandType commandType) { }
+    }
+    public interface IDataBase
+    {
+        Topics.Radical.Data.IDataBase AddParameter(System.Data.IDataParameter parameter);
+        Topics.Radical.Data.IDataBase AddParameterRange(System.Collections.Generic.IEnumerable<System.Data.IDataParameter> range);
+        Topics.Radical.Data.IDataBase AddParameterRange(System.Data.IDataParameterCollection range);
+        Topics.Radical.Data.IDataBase As(System.Data.CommandType commandType);
+        int ExecuteNonQuery();
+        System.Data.IDataReader ExecuteReader();
+        T ExecuteReader<T>()
+            where T :  class, System.Data.IDataReader;
+        object ExecuteScalar();
+        T ExecuteScalar<T>();
+        Topics.Radical.Data.IDataBase UseCommand(string commandText);
+    }
+    public interface IDataBaseProvider
+    {
+        Topics.Radical.Data.IDataBase ConnectingTo(string connectionString);
+        Topics.Radical.Data.IDataBase ConnectingTo(System.Data.Common.DbConnection connection);
+    }
+    [System.ObsoleteAttribute("Use IDataBase instead.")]
+    public interface IDataCommand : System.IDisposable
+    {
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        string CommandText { get; }
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        System.Data.CommandType CommandType { get; }
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        Topics.Radical.Data.IDataCommand AddParameter(System.Data.IDataParameter parameter);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        Topics.Radical.Data.IDataCommand AddParameterRange(System.Collections.Generic.IEnumerable<System.Data.IDataParameter> range);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        Topics.Radical.Data.IDataCommand Command(string commandText);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        int ExecuteNonQuery();
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        int ExecuteNonQuery(string commandText);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        System.Data.IDataReader ExecuteReader();
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        System.Data.IDataReader ExecuteReader(string commandText);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        object ExecuteScalar();
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        object ExecuteScalar(string commandText);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        Topics.Radical.Data.IDataCommand Type(System.Data.CommandType commandType);
+    }
+}
+namespace Topics.Radical.Data.SqlServer
+{
+    
+    public class static KeywordsExtensions
+    {
+        public static string AsSqlServerKeyword(this string keyword) { }
+        public static System.Collections.Generic.IEnumerable<string> AsSqlServerKeywords(this System.Collections.Generic.IEnumerable<string> keywords) { }
+    }
+}
+namespace Topics.Radical.DataBinding
+{
+    
+    public class EnumBinder<T>
+    
+    {
+        public EnumBinder(Topics.Radical.EnumItemDescriptionAttribute attribute, T value) { }
+        public EnumBinder(string caption, T value) { }
+        public EnumBinder(string caption, T value, int index) { }
+        public EnumBinder(string caption, string description, T value, int index) { }
+        public string Caption { get; }
+        public string Description { get; }
+        public int Index { get; }
+        public T Value { get; }
+    }
+}
+namespace Topics.Radical.Diagnostics
+{
+    
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.All, AllowMultiple=false)]
+    public sealed class BuildAttribute : System.Attribute
+    {
+        public BuildAttribute(bool isOptimized) { }
+        public bool IsOptimized { get; }
+        public string Version { get; set; }
+    }
+    public class static EnsurePreviewExtensions
+    {
+        public static Topics.Radical.Validation.IEnsure<T> LogErrorsTo<T>(this Topics.Radical.Validation.IEnsure<T> validator, System.Diagnostics.TraceSource logger) { }
+    }
+    public sealed class New : System.IDisposable
+    {
+        public void Dispose() { }
+        public static System.IDisposable LogicalOperation(object operationId) { }
+    }
+    public class ObjectDumper : System.IDisposable
+    {
+        public void Dispose() { }
+        public static string Dump(object target) { }
+        public static string Dump(object target, int depth) { }
+        public override string ToString() { }
+    }
+    public class static TraceSourceExtensions
+    {
+        public static void Debug(this System.Diagnostics.TraceSource source, int eventId, string message) { }
+        public static void Debug(this System.Diagnostics.TraceSource source, int eventId, string format, params object[] args) { }
+        public static void Debug(this System.Diagnostics.TraceSource source, string message) { }
+        public static void Debug(this System.Diagnostics.TraceSource source, string format, params object[] args) { }
+        public static void Debug(this System.Diagnostics.TraceSource source, string format, System.Func<object[]> args) { }
+        public static void Error(this System.Diagnostics.TraceSource source, string message) { }
+        public static void Error(this System.Diagnostics.TraceSource source, string format, params object[] args) { }
+        public static void Error(this System.Diagnostics.TraceSource source, string message, System.Exception e) { }
+        public static void Error(this System.Diagnostics.TraceSource source, string message, System.Exception e, bool dumpException) { }
+        public static void Information(this System.Diagnostics.TraceSource source, int eventId, string message) { }
+        public static void Information(this System.Diagnostics.TraceSource source, int eventId, string format, params object[] args) { }
+        public static void Information(this System.Diagnostics.TraceSource source, string message) { }
+        public static void Information(this System.Diagnostics.TraceSource source, string format, params object[] args) { }
+        [System.ObsoleteAttribute()]
+        public static void Verbose(this System.Diagnostics.TraceSource source, int eventId, string message) { }
+        [System.ObsoleteAttribute()]
+        public static void Verbose(this System.Diagnostics.TraceSource source, int eventId, string format, params object[] args) { }
+        [System.ObsoleteAttribute()]
+        public static void Verbose(this System.Diagnostics.TraceSource source, string message) { }
+        [System.ObsoleteAttribute()]
+        public static void Verbose(this System.Diagnostics.TraceSource source, string format, params object[] args) { }
+        [System.ObsoleteAttribute()]
+        public static void Verbose(this System.Diagnostics.TraceSource source, string format, System.Func<object[]> args) { }
+        public static void Warning(this System.Diagnostics.TraceSource source, string message) { }
+        public static void Warning(this System.Diagnostics.TraceSource source, string format, params object[] args) { }
+    }
+}
+namespace Topics.Radical.Helpers
+{
+    
+    public class CommandLine
+    {
+        public CommandLine(System.Collections.Generic.IEnumerable<string> args) { }
+        public T As<T>()
+            where T :  class, new () { }
+        public static string AsArguments<T>(T source) { }
+        public bool Contains(string arg) { }
+        public static Topics.Radical.Helpers.CommandLine GetCurrent() { }
+        public bool TryGetValue<T>(string arg, out T value) { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property | System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    public sealed class CommandLineArgumentAttribute : System.Attribute
+    {
+        public CommandLineArgumentAttribute(string argumentName) { }
+        public string[] Aliases { get; set; }
+        public string ArgumentName { get; }
+        public bool IsRequired { get; set; }
+    }
+    public class static EnumHelper
+    {
+        public static System.Collections.Generic.IEnumerable<Topics.Radical.DataBinding.EnumBinder<T>> ExtractBindingData<T>() { }
+        public static System.Collections.Generic.IEnumerable<Topics.Radical.DataBinding.EnumBinder<T>> ExtractBindingData<T>(System.Predicate<T> filter) { }
+        public static System.Collections.Generic.IEnumerable<string> ExtractDescriptions<T>() { }
+        public static System.Collections.Generic.IEnumerable<T> GetValues<T>() { }
+        public static System.Collections.Generic.IEnumerable<object> GetValues(System.Type enumType) { }
+    }
+    public class HashCodeBuilder
+    {
+        public HashCodeBuilder(long initialHashCode) { }
+        public long CombinedHash { get; }
+        public int CombinedHash32 { get; }
+        public void AddObject(object value) { }
+    }
+    public class static KnownRegex
+    {
+        public static readonly string MailAddress;
+        public static readonly string Url;
+        public class static CreditCards
+        {
+            public static readonly string AmericanExpress;
+            public static readonly string Diners;
+            public static readonly string Discover;
+            public static readonly string JCB;
+            public static readonly string MasterCard;
+            public static readonly string Visa;
+        }
+    }
+    public class OSHelper
+    {
+        public OSHelper() { }
+        public int GetOSArchitecture() { }
+        public string GetOSInfo() { }
+    }
+    public class static Password
+    {
+        public static byte[] CreateHash(string clearTextPassword, byte[] passwordSalt) { }
+        public static byte[] CreateHash(string clearTextPassword, byte[] passwordSalt, string hashAlgorithmName) { }
+        public static byte[] CreateRandomSalt() { }
+    }
+    public class RandomStrings
+    {
+        public RandomStrings() { }
+        public bool AllowConsecutiveCharacters { get; set; }
+        public bool AllowRepeatCharacters { get; set; }
+        public bool AllowSymbols { get; set; }
+        public System.Collections.Generic.List<char> Exclusions { get; }
+        public int MaxLenght { get; set; }
+        public int MinLenght { get; set; }
+        public static string GenerateRandom() { }
+        protected int GetCryptographicRandomNumber(int lBound, int uBound) { }
+        protected char GetRandomCharacter() { }
+        public string Next() { }
+    }
+    public class static ReflectionHelper
+    {
+        public static Topics.Radical.Helpers.ReflectionHelper.BoundReflectionHelper<T> BoundTo<T>() { }
+        public static string GetPropertyName<T>(System.Linq.Expressions.Expression<System.Func<T, object>> propertyRef) { }
+        public class BoundReflectionHelper<T>
+        
+        {
+            public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetProperties(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression) { }
+            public System.Reflection.PropertyInfo GetProperty(System.Linq.Expressions.Expression<System.Func<T, object>> propertyRef) { }
+            public string NameOf(System.Linq.Expressions.Expression<System.Func<T, object>> propertyRef) { }
+        }
+    }
+}
+namespace Topics.Radical.Linq
+{
+    
+    public class static EnumerableExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<T> AlternateWith<T>(this System.Collections.Generic.IEnumerable<T> items, T separator) { }
+        public static bool Any(this System.Collections.IEnumerable source) { }
+        public static System.Collections.Generic.IEnumerable<T> AsReadOnly<T>(this System.Collections.Generic.IEnumerable<T> list) { }
+        public static System.Collections.IEnumerable Enumerate(this System.Collections.IEnumerable list, System.Action<object> action) { }
+        public static System.Collections.Generic.IEnumerable<T> FindNodes<T>(this System.Collections.Generic.IEnumerable<T> source, System.Func<T, System.Collections.Generic.IEnumerable<T>> childrenGetter, System.Func<T, bool> condition) { }
+        public static System.Collections.Generic.IEnumerable<T> ForEach<T>(this System.Collections.Generic.IEnumerable<T> list, System.Action<T> action) { }
+        public static System.Collections.Generic.IEnumerable<T> ForEach<TState, T>(this System.Collections.Generic.IEnumerable<T> list, TState initialState, System.Func<TState, T, TState> func) { }
+        public static bool IsChildOfAny<T>(this T item, System.Collections.Generic.IEnumerable<T> parents, System.Func<T, T> parentGetter)
+            where T :  class { }
+        public static bool IsChildOfAny<T>(this T item, System.Collections.Generic.IEnumerable<T> parents, System.Func<T, T> parentGetter, System.Func<T, T, bool> comparer) { }
+        public static bool IsChildOfAny<T>(this T item, System.Collections.Generic.IEnumerable<T> parents, System.Func<T, T> parentGetter, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public static bool None<T>(this System.Collections.Generic.IEnumerable<T> source) { }
+        public static bool None(this System.Collections.IEnumerable source) { }
+        public static System.Collections.Generic.IEnumerable<T> Shouffle<T>(this System.Collections.Generic.IEnumerable<T> items) { }
+        public static System.Collections.Generic.IEnumerable<T> ToFlat<T>(this T root, System.Func<T, System.Collections.Generic.IEnumerable<T>> childrenGetter)
+            where T :  class { }
+        public static System.Collections.Generic.IEnumerable<T> ToFlat<T>(this System.Collections.Generic.IEnumerable<T> source, System.Func<T, System.Collections.Generic.IEnumerable<T>> childrenGetter) { }
+    }
+    public class static ExpressionExtensions
+    {
+        public static string GetMemberName<T>(this System.Linq.Expressions.Expression<System.Func<T>> source) { }
+        public static string GetMemberName<T, TProperty>(this System.Linq.Expressions.Expression<System.Func<T, TProperty>> source) { }
+    }
+    public class static ListExtensions
+    {
+        public static System.Collections.Generic.IList<T> Sync<T>(this System.Collections.Generic.IList<T> source, System.Collections.Generic.IList<T> destination) { }
+    }
+    public class static PredicateBuilder
+    {
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> And<T>(this System.Linq.Expressions.Expression<System.Func<T, bool>> expr1, System.Linq.Expressions.Expression<System.Func<T, bool>> expr2) { }
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> AndIf<T>(this System.Linq.Expressions.Expression<System.Func<T, bool>> expr1, System.Func<bool> condition, System.Linq.Expressions.Expression<System.Func<T, bool>> expr2) { }
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> False<T>() { }
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> Or<T>(this System.Linq.Expressions.Expression<System.Func<T, bool>> expr1, System.Linq.Expressions.Expression<System.Func<T, bool>> expr2) { }
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> True<T>() { }
+    }
+    public class static QueryableExtensions
+    {
+        public static Topics.Radical.ComponentModel.IEntityCollection<TDest> Fill<TSource, TDest>(this System.Linq.IQueryable<TSource> source, Topics.Radical.ComponentModel.IEntityCollection<TDest> destination, System.Func<TSource, TDest> adapter)
+        
+            where TDest :  class { }
+        public static Topics.Radical.ComponentModel.IEntityCollection<TDest> Fill<TSource, TDest>(this System.Linq.IQueryable<TSource> source, Topics.Radical.ComponentModel.IEntityCollection<TDest> destination, System.Func<TSource, Topics.Radical.ComponentModel.IEntityCollection<TDest>, TDest> adapter)
+        
+            where TDest :  class { }
+    }
+    public class static SelectorExtensions
+    {
+        public static T FirstOr<T>(this System.Collections.Generic.IEnumerable<T> source, System.Func<T> defaultValue) { }
+        public static T SingleOr<T>(this System.Collections.Generic.IEnumerable<T> source, System.Func<T> defaultValue) { }
+    }
+}
+namespace Topics.Radical.Messaging
+{
+    
+    public abstract class AbstractMessageHandler<T> : Topics.Radical.ComponentModel.Messaging.IHandleMessage, Topics.Radical.ComponentModel.Messaging.IHandleMessage<T>
+    
+    {
+        protected AbstractMessageHandler() { }
+        public abstract void Handle(object sender, T message);
+        public virtual void Handle(object sender, object message) { }
+        protected virtual bool OnShouldHandle(object sender, T message) { }
+        public bool ShouldHandle(object sender, object message) { }
+    }
+    [System.ObsoleteAttribute("The Radical message broker now supports POCO messages, will be removed in the nex" +
+        "t version.", false)]
+    public abstract class Message : Topics.Radical.ComponentModel.Messaging.ILegacyMessageCompatibility, Topics.Radical.ComponentModel.Messaging.IMessage
+    {
+        protected Message() { }
+        [System.ObsoleteAttribute("The Radical message broker now supports POCO messages, use the default contructor" +
+            ", will be removed in the next version.", false)]
+        protected Message(object sender) { }
+        public object Sender { get; }
+    }
+    public class MessageBroker : Topics.Radical.ComponentModel.Messaging.IMessageBroker
+    {
+        public MessageBroker(Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        public MessageBroker(Topics.Radical.ComponentModel.IDispatcher dispatcher, System.Threading.Tasks.TaskFactory factory) { }
+        public void Broadcast<T>(T message)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Broadcast(System.Type messageType, Topics.Radical.ComponentModel.Messaging.IMessage message) { }
+        public void Broadcast(object sender, object message) { }
+        public void Dispatch<T>(T message)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Dispatch(Topics.Radical.ComponentModel.Messaging.IMessage message) { }
+        public void Dispatch(System.Type messageType, Topics.Radical.ComponentModel.Messaging.IMessage message) { }
+        public void Dispatch(object sender, object message) { }
+        public void Subscribe<T>(object subscriber, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Subscribe<T>(object subscriber, System.Action<object, T> callback) { }
+        public void Subscribe<T>(object subscriber, object sender, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Subscribe<T>(object subscriber, object sender, System.Action<object, T> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, System.Action<object, object> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, System.Action<object, object> callback) { }
+        public void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, T> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, object> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, object> callback) { }
+        public void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, T> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback) { }
+        public void Subscribe<T>(object subscriber, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback) { }
+        public void Subscribe<T>(object subscriber, object sender, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback) { }
+        public void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback) { }
+        public void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback) { }
+        public void Unsubscribe(object subscriber) { }
+        public void Unsubscribe(object subscriber, object sender) { }
+        public void Unsubscribe<T>(object subscriber) { }
+        public void Unsubscribe<T>(object subscriber, object sender) { }
+        public void Unsubscribe<T>(object subscriber, System.Delegate callback) { }
+    }
+    [System.ObsoleteAttribute("The Radical message broker now supports POCO messages, inherits from AbstractMess" +
+        "ageHandler<T> or implement IHandleMessage<T> interface directly.", false)]
+    public abstract class MessageHandler<T> : Topics.Radical.ComponentModel.Messaging.IMessageHandler, Topics.Radical.ComponentModel.Messaging.IMessageHandler<T>
+        where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage
+    {
+        protected MessageHandler() { }
+        public abstract void Handle(T message);
+        public virtual void Handle(Topics.Radical.ComponentModel.Messaging.IMessage message) { }
+        protected virtual bool OnShouldHandle(T message) { }
+        public bool ShouldHandle(Topics.Radical.ComponentModel.Messaging.IMessage message) { }
+    }
+    public enum SubscriptionPriority
+    {
+        Highest = 3,
+        High = 2,
+        AboveNormal = 1,
+        Normal = 0,
+        BelowNormal = -1,
+        Low = -2,
+        Lowest = -3,
+    }
+}
+namespace Topics.Radical.Model
+{
+    
+    public class AddingNewEventArgs<T> : System.ComponentModel.CancelEventArgs
+    
+    {
+        public AddingNewEventArgs() { }
+        public bool AutoCommit { get; set; }
+        public T NewItem { get; set; }
+    }
+    public abstract class Entity : System.ComponentModel.INotifyPropertyChanged, System.IDisposable
+    {
+        protected Entity() { }
+        protected System.ComponentModel.EventHandlerList Events { get; }
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        protected virtual void EnsureNotDisposed() { }
+        protected override void Finalize() { }
+        protected virtual Topics.Radical.Model.PropertyMetadata<T> GetDefaultMetadata<T>(string propertyName) { }
+        protected Topics.Radical.Model.PropertyMetadata<T> GetPropertyMetadata<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected Topics.Radical.Model.PropertyMetadata<T> GetPropertyMetadata<T>(string propertyName) { }
+        protected T GetPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected T GetPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, System.Func<T> initialValueSetter) { }
+        protected internal T GetPropertyValue<T>(string propertyName) { }
+        protected virtual bool HasMetadata<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected virtual void OnPropertyChanged(System.ComponentModel.PropertyChangedEventArgs e) { }
+        protected void OnPropertyChanged(string propertyName) { }
+        protected void OnPropertyChanged<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected void ResumeNotificationsFor<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected Topics.Radical.Model.PropertyMetadata<T> SetInitialPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, T value) { }
+        protected Topics.Radical.Model.PropertyMetadata<T> SetInitialPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, System.Func<T> lazyValue) { }
+        protected Topics.Radical.Model.PropertyMetadata<T> SetInitialPropertyValue<T>(string property, T value) { }
+        protected virtual void SetPropertyMetadata<T>(Topics.Radical.Model.PropertyMetadata<T> metadata) { }
+        protected void SetPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, T data) { }
+        protected void SetPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, T data, Topics.Radical.Model.PropertyValueChanged<T> pvc) { }
+        protected void SetPropertyValue<T>(string propertyName, T data) { }
+        protected virtual void SetPropertyValue<T>(string propertyName, T data, Topics.Radical.Model.PropertyValueChanged<T> pvc) { }
+        protected void SetPropertyValueCore<T>(string propertyName, T data, Topics.Radical.Model.PropertyValueChanged<T> pvc) { }
+        protected System.IDisposable SuspendNotificationsOf<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+    }
+    public class EntityCollection<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IComponent, System.ComponentModel.ISite, System.ComponentModel.ISupportInitialize, System.IDisposable, System.IServiceProvider, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable, Topics.Radical.ComponentModel.IEntityCollection<T>
+    
+    {
+        protected static readonly string SerializationKey;
+        public EntityCollection() { }
+        public EntityCollection(int capacity) { }
+        public EntityCollection(System.Collections.Generic.IEnumerable<T> collection) { }
+        public EntityCollection(System.Collections.Generic.IList<T> storage) { }
+        protected EntityCollection(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public virtual bool AllowNew { get; }
+        public int Count { get; }
+        public Topics.Radical.ComponentModel.IEntityView<T> DefaultView { get; }
+        protected System.ComponentModel.EventHandlerList Events { get; }
+        public bool IsInitializing { get; }
+        protected virtual bool IsReadOnly { get; }
+        public T this[int index] { get; set; }
+        public Topics.Radical.Model.EntityCollection<T>.CollectionSettings Settings { get; }
+        protected System.Collections.Generic.IList<T> Storage { get; }
+        public event System.EventHandler<Topics.Radical.ComponentModel.CollectionChangedEventArgs<T>> CollectionChanged;
+        public event System.EventHandler Disposed;
+        public void Add(T item) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<T> list) { }
+        public virtual void BeginInit() { }
+        public void Clear() { }
+        public bool Contains(T item) { }
+        public void CopyTo(T[] array) { }
+        public void CopyTo(T[] array, int arrayIndex) { }
+        public T CreateNew() { }
+        public Topics.Radical.ComponentModel.IEntityView<T> CreateView() { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        public void EndInit() { }
+        public virtual void EndInit(bool notify) { }
+        protected void EnsureNotDisposed() { }
+        protected override void Finalize() { }
+        public virtual System.Collections.Generic.IEnumerator<T> GetEnumerator() { }
+        protected virtual T GetValueAt(int index) { }
+        public int IndexOf(T item) { }
+        public void Insert(int index, T item) { }
+        public void Move(T item, int newIndex) { }
+        public void Move(int oldIndex, int newIndex) { }
+        protected virtual void OnAddCompleted(int index, T value) { }
+        protected virtual void OnAddRange(System.Collections.Generic.IEnumerable<T> rangeToAdd) { }
+        protected virtual void OnAddRangeCompleted(System.Collections.Generic.IEnumerable<T> addedRange) { }
+        protected virtual void OnClearCompleted(System.Collections.Generic.IEnumerable<T> clearedItems) { }
+        protected virtual void OnCollectionChanged(Topics.Radical.ComponentModel.CollectionChangedEventArgs<T> e) { }
+        protected virtual Topics.Radical.ComponentModel.IEntityView<T> OnCreateView() { }
+        protected virtual T OnCreatingNew() { }
+        protected virtual void OnDeserialization(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected virtual void OnDeserializationCompleted(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected virtual void OnDisposed() { }
+        protected virtual void OnGetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected virtual void OnInitialize() { }
+        protected virtual void OnInsert(Topics.Radical.Model.InsertEventArgs<T> e) { }
+        protected virtual void OnInsertCompleted(int index, T value) { }
+        protected virtual void OnMoveCompleted(int oldIndex, int newIndex, T value) { }
+        protected virtual void OnRemoveCompleted(T value, int index) { }
+        protected virtual void OnSetValueAt(Topics.Radical.Model.SetValueAtEventArgs<T> e) { }
+        protected virtual void OnSetValueAtCompleted(int index, T newValue, T overwrittenValue) { }
+        public bool Remove(T item) { }
+        protected bool Remove(T item, bool notify) { }
+        public void RemoveAt(int index) { }
+        protected void RemoveAt(int index, bool notify) { }
+        public void Reverse() { }
+        protected void SetValueAt(int index, T value) { }
+        public T[] ToArray() { }
+        protected virtual void UnwireListItem(T item) { }
+        protected virtual void WireListItem(T item) { }
+        public class CollectionSettings<T>
+        
+        {
+            public CollectionSettings() { }
+            public bool NotifyListItemPropertyChanged { get; set; }
+        }
+    }
+    public class EntityItemView<T> : System.ComponentModel.ICustomTypeDescriptor, System.ComponentModel.IDataErrorInfo, System.ComponentModel.IEditableObject, System.ComponentModel.INotifyPropertyChanged, Topics.Radical.ComponentModel.IEntityItemView, Topics.Radical.ComponentModel.IEntityItemView<T>, Topics.Radical.ComponentModel.INotifyEditableObject
+    
+    {
+        public EntityItemView(Topics.Radical.ComponentModel.IEntityView<T> view, T entityItem) { }
+        public T EntityItem { get; }
+        public virtual string Error { get; }
+        public virtual string this[string columnName] { get; }
+        public Topics.Radical.ComponentModel.IEntityView<T> View { get; }
+        public event System.EventHandler EditBegun;
+        public event System.EventHandler EditCanceled;
+        public event System.EventHandler EditEnded;
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        public void BeginEdit() { }
+        public void CancelEdit() { }
+        public void Delete() { }
+        public void EndEdit() { }
+        public override bool Equals(object obj) { }
+        public TValue GetCustomValue<TValue>(string customPropertyName) { }
+        public override int GetHashCode() { }
+        public void NotifyPropertyChanged(string propertyName) { }
+        protected virtual void OnEditBegun() { }
+        protected virtual void OnEditCanceled() { }
+        protected virtual void OnEditEnded() { }
+        protected virtual void OnInit() { }
+        protected virtual void OnPropertyChanged(System.ComponentModel.PropertyChangedEventArgs args) { }
+        public void SetCustomValue<TValue>(string customPropertyName, TValue value) { }
+    }
+    public abstract class EntityItemViewFilterBase<T> : Topics.Radical.ComponentModel.IEntityItemViewFilter, Topics.Radical.ComponentModel.IEntityItemViewFilter<T>
+    
+    {
+        protected EntityItemViewFilterBase() { }
+        public abstract bool ShouldInclude(T item);
+        public override string ToString() { }
+    }
+    public class EntityItemViewSortComparer<T> : System.Collections.Generic.IComparer<Topics.Radical.ComponentModel.IEntityItemView<T>>
+    
+    {
+        public EntityItemViewSortComparer(System.ComponentModel.ListSortDescriptionCollection sortDescriptions) { }
+        protected System.ComponentModel.ListSortDescriptionCollection SortDescriptions { get; }
+        public int Compare(Topics.Radical.ComponentModel.IEntityItemView<T> x, Topics.Radical.ComponentModel.IEntityItemView<T> y) { }
+        protected virtual int OnCompare(Topics.Radical.ComponentModel.IEntityItemView<T> x, Topics.Radical.ComponentModel.IEntityItemView<T> y) { }
+    }
+    public class EntityView<T> : System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IEntityItemView<T>>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IBindingList, System.ComponentModel.IBindingListView, System.ComponentModel.ICancelAddNew, System.ComponentModel.IComponent, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.IRaiseItemChangedEvents, System.ComponentModel.ISupportInitialize, System.ComponentModel.ITypedList, System.IDisposable, System.IServiceProvider, Topics.Radical.ComponentModel.IEntityView, Topics.Radical.ComponentModel.IEntityView<T>
+    
+    {
+        public EntityView() { }
+        public EntityView(Topics.Radical.ComponentModel.IEntityCollection<T> list) { }
+        public EntityView(T[] list) { }
+        public EntityView(System.Collections.Generic.IList<T> list) { }
+        protected EntityView(System.Collections.IList list) { }
+        public virtual bool AllowEdit { get; set; }
+        public bool AllowMove { get; }
+        public virtual bool AllowNew { get; set; }
+        public virtual bool AllowRemove { get; set; }
+        public virtual bool AllowSort { get; set; }
+        public bool AutoGenerateProperties { get; set; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+        public virtual System.ComponentModel.IContainer Container { get; }
+        public int Count { get; }
+        protected System.Collections.Generic.IDictionary<string, Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T>> CustomProperties { get; }
+        public System.Collections.IList DataSource { get; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+        public virtual bool DesignMode { get; }
+        protected System.ComponentModel.EventHandlerList Events { get; }
+        public Topics.Radical.ComponentModel.IEntityItemViewFilter<T> Filter { get; set; }
+        protected Topics.Radical.Model.Indexer<T> Indexer { get; }
+        public bool IsAddingNew { get; }
+        public bool IsArrayBased { get; }
+        public bool IsDetached { get; }
+        public bool IsFiltered { get; }
+        protected bool IsInitializing { get; }
+        public bool IsSorted { get; }
+        public Topics.Radical.ComponentModel.IEntityItemView<T> this[int index] { get; set; }
+        protected Topics.Radical.ComponentModel.IEntityItemView<T> PendingNewItem { get; }
+        public bool RaisesItemChangedEvents { get; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+        public virtual System.ComponentModel.ISite Site { get; set; }
+        public System.ComponentModel.ListSortDescriptionCollection SortDescriptions { get; }
+        public System.ComponentModel.ListSortDirection SortDirection { get; }
+        public System.ComponentModel.PropertyDescriptor SortProperty { get; }
+        public event System.EventHandler<Topics.Radical.Model.AddingNewEventArgs<T>> AddingNew;
+        public event System.EventHandler Disposed;
+        public event System.EventHandler FilterChanged;
+        public event System.ComponentModel.ListChangedEventHandler ListChanged;
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        public event System.EventHandler SortChanged;
+        public void AddIndex(System.ComponentModel.PropertyDescriptor property) { }
+        public void AddIndex(string propertyName) { }
+        public Topics.Radical.ComponentModel.IEntityItemView<T> AddNew(System.Action<Topics.Radical.Model.AddingNewEventArgs<T>> addNewInterceptor) { }
+        public Topics.Radical.ComponentModel.IEntityItemView<T> AddNew() { }
+        public virtual Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> customProperty) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(string propertyName) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(string propertyName, string displayName) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter, System.Func<TProperty> defaultValueInterceptor) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter, Topics.Radical.ComponentModel.EntityItemViewValueSetter<T, TProperty> setter) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter, Topics.Radical.ComponentModel.EntityItemViewValueSetter<T, TProperty> setter, System.Func<TProperty> defaultValueInterceptor) { }
+        public void ApplyFilter(System.Predicate<T> predicate) { }
+        public void ApplySort(System.ComponentModel.PropertyDescriptor property, System.ComponentModel.ListSortDirection direction) { }
+        public void ApplySort(System.ComponentModel.ListSortDescriptionCollection sorts) { }
+        public void ApplySort(string sort) { }
+        public void ApplySort(System.Collections.Generic.IComparer<Topics.Radical.ComponentModel.IEntityItemView<T>> comparer) { }
+        public void CancelNew() { }
+        public void CancelNew(int itemIndex) { }
+        protected internal Topics.Radical.ComponentModel.IEntityItemView<T> CreateEntityItemView(T sourceItem) { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        public void EndNew() { }
+        public void EndNew(int itemIndex) { }
+        protected override void Finalize() { }
+        public int Find(System.ComponentModel.PropertyDescriptor property, object key) { }
+        public int Find(string propertyName, object key) { }
+        public System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T>> GetCustomProperties() { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> GetCustomProperty(string name) { }
+        public TValue GetCustomPropertyValue<TValue>(string customPropertyName, Topics.Radical.ComponentModel.IEntityItemView<T> owner) { }
+        protected virtual TValue GetCustomPropertyValueCore<TValue>(string customPropertyName, Topics.Radical.ComponentModel.IEntityItemView<T> owner) { }
+        public System.ComponentModel.PropertyDescriptor GetProperty(string name) { }
+        public virtual object GetService(System.Type serviceType) { }
+        public int IndexOf(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public int IndexOf(T item) { }
+        protected bool IsInAddingNewQueue(T item) { }
+        public bool IsPropertyMappingDefined(string propertyName) { }
+        public void Move(int sourceIndex, int newIndex) { }
+        public void Move(Topics.Radical.ComponentModel.IEntityItemView<T> item, int newIndex) { }
+        protected virtual void OnAddingNew(Topics.Radical.Model.AddingNewEventArgs<T> e) { }
+        protected virtual void OnCancelNew(int itemIndex) { }
+        protected virtual void OnCollectionChanged(Topics.Radical.Model.RebuildIndexesEventArgs e, Topics.Radical.ComponentModel.CollectionChangeType changeType) { }
+        protected virtual Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> OnCreateDescriptor(System.Reflection.PropertyInfo property) { }
+        protected virtual System.Collections.Generic.IComparer<Topics.Radical.ComponentModel.IEntityItemView<T>> OnCreateSortComparer() { }
+        protected virtual void OnEndNew(int index) { }
+        protected virtual void OnEndNewCompleted(Topics.Radical.Model.RebuildIndexesEventArgs e) { }
+        protected virtual void OnEntityItemViewEditBegun(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        protected virtual void OnEntityItemViewEditCanceled(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        protected virtual void OnEntityItemViewEditEnded(Topics.Radical.Model.RebuildIndexesEventArgs e) { }
+        protected virtual void OnFilterChanged() { }
+        protected virtual System.ComponentModel.PropertyDescriptorCollection OnGetItemProperties(System.ComponentModel.PropertyDescriptor[] listAccessors) { }
+        protected virtual string OnGetListName(System.ComponentModel.PropertyDescriptor[] listAccessors) { }
+        protected virtual void OnInit() { }
+        protected virtual void OnListChanged(System.ComponentModel.ListChangedEventArgs e) { }
+        protected virtual void OnLoad() { }
+        protected void OnPropertyChanged<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected virtual void OnPropertyChanged(string propertyName) { }
+        protected virtual void OnRemovedAt(Topics.Radical.Model.RebuildIndexesEventArgs e) { }
+        protected virtual void OnSortChanged() { }
+        protected internal void OnUnwireEntityItemView(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        protected internal void OnWireEntityItemView(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public virtual void Refresh() { }
+        public void RemoveFilter() { }
+        public void RemoveIndex(System.ComponentModel.PropertyDescriptor property) { }
+        public void RemoveIndex(string propertyName) { }
+        public virtual bool RemovePropertyMapping(Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> customProperty) { }
+        public bool RemovePropertyMapping(string propertyName) { }
+        public void RemoveSort() { }
+        public void SetCustomPropertyValue<TValue>(string customPropertyName, Topics.Radical.ComponentModel.IEntityItemView<T> owner, TValue value) { }
+    }
+    public sealed class Indexer<T> : System.Collections.Generic.ICollection<Topics.Radical.ComponentModel.IEntityItemView<T>>, System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IEntityItemView<T>>, System.Collections.IEnumerable
+    
+    {
+        public int Count { get; }
+        public bool IsReadOnly { get; }
+        public Topics.Radical.ComponentModel.IEntityItemView<T> this[int index] { get; }
+        public void Add(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public void AddIndex(System.ComponentModel.PropertyDescriptor property) { }
+        public void ApplySort() { }
+        public void Clear() { }
+        public void ClearIndexes() { }
+        public bool Contains(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public bool Contains(T item) { }
+        public void CopyTo(Topics.Radical.ComponentModel.IEntityItemView<>[] array, int arrayIndex) { }
+        public int Find(System.ComponentModel.PropertyDescriptor property, object key) { }
+        public int FindEntityItemViewIndexInView(int entityIndexInDataSource) { }
+        public int FindObjectIndexInDataSource(int objectItemViewIndexInView) { }
+        public int IndexOf(T item) { }
+        public int IndexOf(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public void Rebuild() { }
+        public bool Remove(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public void RemoveAt(int index) { }
+        public void RemoveIndex(System.ComponentModel.PropertyDescriptor property) { }
+        public void RemoveSort() { }
+    }
+    public class InsertEventArgs<T> : System.ComponentModel.CancelEventArgs
+    
+    {
+        public InsertEventArgs(int index, T newValue) { }
+        public int Index { get; }
+        public T NewValue { get; }
+    }
+    public abstract class MementoEntity : Topics.Radical.Model.Entity, Topics.Radical.ComponentModel.ChangeTracking.IMemento
+    {
+        protected MementoEntity() { }
+        protected MementoEntity(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService memento) { }
+        protected MementoEntity(bool registerAsTransient) { }
+        protected MementoEntity(Topics.Radical.ComponentModel.ChangeTracking.ChangeTrackingRegistration registration) { }
+        protected MementoEntity(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService memento, Topics.Radical.ComponentModel.ChangeTracking.ChangeTrackingRegistration registration) { }
+        protected MementoEntity(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService memento, bool registerAsTransient) { }
+        protected virtual bool IsTracking { get; }
+        protected Topics.Radical.ComponentModel.ChangeTracking.IChange CacheChange<T>(string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restore) { }
+        protected Topics.Radical.ComponentModel.ChangeTracking.IChange CacheChange<T>(string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restore, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> commit) { }
+        protected Topics.Radical.ComponentModel.ChangeTracking.IChange CacheChange<T>(string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restore, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> commit, Topics.Radical.ComponentModel.ChangeTracking.AddChangeBehavior direction) { }
+        protected virtual Topics.Radical.ComponentModel.ChangeTracking.IChange CacheChangeOnRejectCallback<T>(string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> commitCallback, Topics.Radical.ComponentModel.ChangeTracking.ChangeRejectedEventArgs<T> args) { }
+        protected override void Dispose(bool disposing) { }
+        protected override void EnsureNotDisposed() { }
+        protected override Topics.Radical.Model.PropertyMetadata<T> GetDefaultMetadata<T>(string propertyName) { }
+        protected Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService GetTrackingService() { }
+        protected virtual void OnMementoChanged(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService newMemento, Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService oldMemento) { }
+        protected virtual void OnRegisterTransient(Topics.Radical.ComponentModel.ChangeTracking.TransientRegistration transientRegistration) { }
+        protected void RegisterTransient() { }
+        protected Topics.Radical.Model.MementoPropertyMetadata<T> SetInitialPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, T value, bool trackChanges) { }
+        protected Topics.Radical.Model.MementoPropertyMetadata<T> SetInitialPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, System.Func<T> lazyValue, bool trackChanges) { }
+        protected Topics.Radical.Model.MementoPropertyMetadata<T> SetInitialPropertyValue<T>(string property, T value, bool trackChanges) { }
+        protected override void SetPropertyValue<T>(string propertyName, T data, Topics.Radical.Model.PropertyValueChanged<T> pvc) { }
+    }
+    public class MementoEntityCollection<T> : Topics.Radical.Model.EntityCollection<T>, Topics.Radical.ComponentModel.ChangeTracking.IMemento
+    
+    {
+        public MementoEntityCollection() { }
+        public MementoEntityCollection(int capacity) { }
+        public MementoEntityCollection(System.Collections.Generic.IEnumerable<T> collection) { }
+        public MementoEntityCollection(System.Collections.Generic.IList<T> storage) { }
+        protected MementoEntityCollection(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected bool IsCachingSuspended { get; }
+        protected virtual bool IsTracking { get; }
+        public Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Memento { get; set; }
+        public override void BeginInit() { }
+        public override void EndInit(bool notify) { }
+        protected override void OnAddCompleted(int index, T value) { }
+        protected override void OnAddRangeCompleted(System.Collections.Generic.IEnumerable<T> addedRange) { }
+        protected override void OnClearCompleted(System.Collections.Generic.IEnumerable<T> clearedItems) { }
+        protected override void OnDeserialization(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected override void OnDeserializationCompleted(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected override void OnInitialize() { }
+        protected override void OnInsertCompleted(int index, T value) { }
+        protected virtual void OnMementoChanged(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService newMemento, Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService oldMemento) { }
+        protected override void OnMoveCompleted(int oldIndex, int newIndex, T value) { }
+        protected override void OnRemoveCompleted(T value, int index) { }
+        protected override void OnSetValueAtCompleted(int index, T newValue, T overwrittenValue) { }
+        protected void ResumeCaching() { }
+        protected void SuspendCaching() { }
+        protected override void WireListItem(T item) { }
+    }
+    public class static MementoPropertyMetadata
+    {
+        public static Topics.Radical.Model.MementoPropertyMetadata<T> Create<T>(object propertyOwner, System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public static Topics.Radical.Model.MementoPropertyMetadata<T> Create<T>(object propertyOwner, string propertyName) { }
+    }
+    public class MementoPropertyMetadata<T> : Topics.Radical.Model.PropertyMetadata<T>, Topics.Radical.ComponentModel.ChangeTracking.IMementoPropertyMetadata
+    
+    {
+        public MementoPropertyMetadata(object propertyOwner, string propertyName) { }
+        public MementoPropertyMetadata(object propertyOwner, System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public bool TrackChanges { get; set; }
+        public Topics.Radical.Model.MementoPropertyMetadata<T> DisableChangesTracking() { }
+        public Topics.Radical.Model.MementoPropertyMetadata<T> EnableChangesTracking() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property | System.AttributeTargets.All)]
+    public class MementoPropertyMetadataAttribute : Topics.Radical.Model.PropertyMetadataAttribute
+    {
+        public MementoPropertyMetadataAttribute() { }
+        public bool TrackChanges { get; set; }
+    }
+    public sealed class NullDataContext : System.IDisposable, Topics.Radical.ComponentModel.IDataContext
+    {
+        public static readonly Topics.Radical.ComponentModel.IDataContext Instance;
+        public bool HasPendingChanges { get; }
+        public Topics.Radical.ComponentModel.ITransaction Transaction { get; }
+        public Topics.Radical.ComponentModel.ITransaction BeginTransaction() { }
+        public Topics.Radical.ComponentModel.ITransaction BeginTransaction(System.Data.IsolationLevel isolationLevel) { }
+        public void Clear() { }
+        public void Delete(object entity) { }
+        public void Detach(object entity) { }
+        public void Dispose() { }
+        public int Execute<TCommand>(TCommand command)
+            where TCommand : Topics.Radical.ComponentModel.QueryModel.IBatchCommand { }
+        public void FlushChanges() { }
+        public T GetByKey<T>(object key) { }
+        public System.Collections.Generic.IList<TResult> GetByQuery<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec) { }
+        public System.Collections.Generic.IEnumerable<TResult> GetBySpecification<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult> specification) { }
+        public TResult GetScalar<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec) { }
+        public void Insert(object entity) { }
+        public bool IsAttached(object entity) { }
+        public void Save(object entity) { }
+        public void Update(object entity) { }
+    }
+    public sealed class PredicateEntityItemViewFilter<T> : Topics.Radical.Model.EntityItemViewFilterBase<T>
+    
+    {
+        public PredicateEntityItemViewFilter(System.Predicate<T> filterDelegate) { }
+        public PredicateEntityItemViewFilter(System.Predicate<T> filterDelegate, string filterName) { }
+        public System.Predicate<T> FilterDelegate { get; }
+        public override bool ShouldInclude(T item) { }
+        public override string ToString() { }
+    }
+    public abstract class PropertyMetadata : System.IDisposable
+    {
+        protected PropertyMetadata(object propertyOwner, string propertyName) { }
+        public bool NotifyChanges { get; set; }
+        protected System.Reflection.PropertyInfo Property { get; }
+        public string PropertyName { get; }
+        public Topics.Radical.Model.PropertyMetadata AddCascadeChangeNotifications<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public Topics.Radical.Model.PropertyMetadata AddCascadeChangeNotifications(string property) { }
+        public static Topics.Radical.Model.PropertyMetadata<T> Create<T>(object propertyOwner, System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public static Topics.Radical.Model.PropertyMetadata<T> Create<T>(object propertyOwner, string propertyName) { }
+        public Topics.Radical.Model.PropertyMetadata DisableChangesNotifications() { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        public Topics.Radical.Model.PropertyMetadata EnableChangesNotifications() { }
+        protected override void Finalize() { }
+        public System.Collections.Generic.IEnumerable<string> GetCascadeChangeNotifications() { }
+        public abstract Topics.Radical.Model.PropertyValue GetDefaultValue();
+        public Topics.Radical.Model.PropertyMetadata RemoveCascadeChangeNotifications<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public Topics.Radical.Model.PropertyMetadata RemoveCascadeChangeNotifications(string property) { }
+        public abstract void SetDefaultValue(Topics.Radical.Model.PropertyValue value);
+    }
+    public class PropertyMetadata<T> : Topics.Radical.Model.PropertyMetadata
+    
+    {
+        public PropertyMetadata(object propertyOwner, string propertyName) { }
+        public PropertyMetadata(object propertyOwner, System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public virtual T DefaultValue { get; set; }
+        public System.Func<T> DefaultValueInterceptor { get; set; }
+        protected override void Dispose(bool disposing) { }
+        public override Topics.Radical.Model.PropertyValue GetDefaultValue() { }
+        public Topics.Radical.Model.PropertyMetadata<T> OnChanged(System.Action<Topics.Radical.Model.PropertyValueChangedArgs<T>> propertyChangedHandler) { }
+        public override void SetDefaultValue(Topics.Radical.Model.PropertyValue value) { }
+        public Topics.Radical.Model.PropertyMetadata<T> WithDefaultValue(T defaultValue) { }
+        public Topics.Radical.Model.PropertyMetadata<T> WithDefaultValue(System.Func<T> defaultValueInterceptor) { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property | System.AttributeTargets.All)]
+    public class PropertyMetadataAttribute : System.Attribute
+    {
+        public PropertyMetadataAttribute() { }
+    }
+    public abstract class PropertyValue
+    {
+        protected PropertyValue() { }
+        public abstract object GetValue();
+    }
+    public class PropertyValue<T> : Topics.Radical.Model.PropertyValue
+    
+    {
+        public PropertyValue(T value) { }
+        public T Value { get; }
+        public override object GetValue() { }
+    }
+    public delegate void PropertyValueChanged<T>(Topics.Radical.Model.PropertyValueChangedArgs<T> e);
+    public class PropertyValueChangedArgs<T>
+    
+    {
+        public PropertyValueChangedArgs(T newValue, T oldValue) { }
+        public T NewValue { get; }
+        public T OldValue { get; }
+    }
+    public class RebuildIndexesEventArgs : System.ComponentModel.CancelEventArgs
+    {
+        public RebuildIndexesEventArgs(int index) { }
+        public int Index { get; }
+    }
+    public class SetValueAtEventArgs<T> : Topics.Radical.Model.InsertEventArgs<T>
+    
+    {
+        public SetValueAtEventArgs(int index, T newValue, T oldValue) { }
+        public T OldValue { get; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property | System.AttributeTargets.All)]
+    public sealed class SkipPropertyValidationAttribute : System.Attribute
+    {
+        public SkipPropertyValidationAttribute() { }
+    }
+    public sealed class ViewAllEntityItemViewFilter<T> : Topics.Radical.Model.EntityItemViewFilterBase<T>
+    
+    {
+        public static Topics.Radical.ComponentModel.IEntityItemViewFilter Instance { get; }
+        public override bool ShouldInclude(T item) { }
+        public override string ToString() { }
+    }
+}
+namespace Topics.Radical.Model.Factories
+{
+    
+    public class ChangeTrackingServiceFactory : Topics.Radical.ComponentModel.Factories.IChangeTrackingServiceFactory
+    {
+        public ChangeTrackingServiceFactory(System.IServiceProvider container) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Create() { }
+    }
+}
+namespace Topics.Radical.Model.Providers
+{
+    
+    public class QuerySystemManager : Topics.Radical.ComponentModel.QueryModel.IQuerySystemManager
+    {
+        public QuerySystemManager(System.IServiceProvider container) { }
+        public Topics.Radical.ComponentModel.QueryModel.IBatchCommandEngine<TCommand, TProvider> GetBatchCommandEngine<TCommand, TProvider>(TCommand command)
+            where TCommand : Topics.Radical.ComponentModel.QueryModel.IBatchCommand { }
+        public Topics.Radical.ComponentModel.QueryModel.IQueryEngine<TSource, TResult, TProvider> GetQueryEngine<TSource, TResult, TProvider>(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec) { }
+        public Topics.Radical.ComponentModel.QueryModel.IScalarEvaluator<TSource, TResult, TProvider> GetScalarEvaluator<TSource, TResult, TProvider>(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec) { }
+    }
+}
+namespace Topics.Radical.Model.QueryModel
+{
+    
+    public abstract class AbstractQueryEngine<TQuery, TSource, TResult, TProvider> : Topics.Radical.ComponentModel.QueryModel.IQueryEngine<TSource, TResult, TProvider>, Topics.Radical.ComponentModel.QueryModel.IQueryEngine<TQuery, TSource, TResult, TProvider>
+        where TQuery : Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<, >
+    
+    
+    
+    {
+        protected AbstractQueryEngine() { }
+        public abstract System.Collections.Generic.IList<TResult> ExecuteQuery(TQuery querySpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+        public System.Collections.Generic.IList<TResult> ExecuteQuery(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider) { }
+    }
+    public abstract class AbstractQuerySpecification<TSource, TResult> : Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult>, Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult>
+    
+    
+    {
+        protected AbstractQuerySpecification() { }
+    }
+    public abstract class AbstractScalarEvaluator<TScalar, TSource, TResult, TProvider> : Topics.Radical.ComponentModel.QueryModel.IScalarEvaluator<TSource, TResult, TProvider>, Topics.Radical.ComponentModel.QueryModel.IScalarEvaluator<TScalar, TSource, TResult, TProvider>
+        where TScalar : Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<, >
+    
+    
+    
+    {
+        protected AbstractScalarEvaluator() { }
+        public abstract TResult Evaluate(TScalar scalarSpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+        public TResult Evaluate(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider) { }
+    }
+    public abstract class AbstractScalarSpecification<TSource, TResult> : Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult>, Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult>
+    
+    
+    {
+        protected AbstractScalarSpecification() { }
+    }
+    public class AllEntitiesQuery<TSource, TResult> : Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult>, Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult>
+    
+    
+    {
+        public AllEntitiesQuery() { }
+    }
+    public class EntitiesByKeywordsQuery<TSource, TResult> : Topics.Radical.Model.QueryModel.AbstractQuerySpecification<TSource, TResult>
+    
+    
+    {
+        public EntitiesByKeywordsQuery(System.Collections.Generic.IEnumerable<string> keywords) { }
+        public System.Collections.Generic.IEnumerable<string> Keywords { get; }
+        public override string ToString() { }
+    }
+    public class EntityByKeyQuery<TSource, TResult> : Topics.Radical.Model.QueryModel.AbstractScalarSpecification<TSource, TResult>
+    
+    
+    {
+        public EntityByKeyQuery(Topics.Radical.ComponentModel.IKey key) { }
+        public Topics.Radical.ComponentModel.IKey Key { get; }
+        public override string ToString() { }
+    }
+}
+namespace Topics.Radical.Model.Services
+{
+    
+    public class Int32KeyService : Topics.Radical.ComponentModel.IKeyService
+    {
+        public Int32KeyService() { }
+        public Topics.Radical.ComponentModel.IKey GenerateEmpty() { }
+    }
+    public class static KeyServiceProxy
+    {
+        public static Topics.Radical.ComponentModel.IKeyService CurrentService { get; set; }
+    }
+}
+namespace Topics.Radical.Observers
+{
+    
+    public abstract class AbstractMonitor : Topics.Radical.ComponentModel.IMonitor
+    {
+        protected AbstractMonitor() { }
+        protected AbstractMonitor(Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        protected AbstractMonitor(object source) { }
+        protected AbstractMonitor(object source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        protected Topics.Radical.ComponentModel.IDispatcher Dispatcher { get; }
+        protected System.WeakReference WeakSource { get; }
+        public event System.EventHandler Changed;
+        public void NotifyChanged() { }
+        protected virtual void OnChanged() { }
+        protected abstract void OnStopMonitoring(bool targetDisposed);
+        protected virtual void StartMonitoring(object source) { }
+        public void StopMonitoring() { }
+    }
+    public abstract class AbstractMonitor<T> : Topics.Radical.Observers.AbstractMonitor, Topics.Radical.ComponentModel.IMonitor, Topics.Radical.ComponentModel.IMonitor<T>
+    
+    {
+        protected AbstractMonitor(T source) { }
+        protected AbstractMonitor(T source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        protected AbstractMonitor() { }
+        protected AbstractMonitor(Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        public T Source { get; }
+    }
+    public class static BrokerObserver
+    {
+        public static Topics.Radical.Observers.MessageBrokerMonitor Using(Topics.Radical.ComponentModel.Messaging.IMessageBroker broker) { }
+    }
+    public class EntityViewListChangedMonitor : Topics.Radical.Observers.AbstractMonitor<Topics.Radical.ComponentModel.IEntityView>
+    {
+        public EntityViewListChangedMonitor(Topics.Radical.ComponentModel.IEntityView source) { }
+        public EntityViewListChangedMonitor() { }
+        public EntityViewListChangedMonitor(Topics.Radical.ComponentModel.IEntityView source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        public EntityViewListChangedMonitor(Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        public void Observe(Topics.Radical.ComponentModel.IEntityView source) { }
+        protected override void OnStopMonitoring(bool targetDisposed) { }
+        protected override void StartMonitoring(object source) { }
+    }
+    public class MementoMonitor : Topics.Radical.Observers.AbstractMonitor<Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService>
+    {
+        public MementoMonitor(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService source) { }
+        public MementoMonitor(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        protected override void OnStopMonitoring(bool targetDisposed) { }
+    }
+    public class static MementoObserver
+    {
+        public static Topics.Radical.Observers.MementoMonitor Monitor(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService source) { }
+        public static Topics.Radical.Observers.MementoMonitor Monitor(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+    }
+    public class MessageBrokerMonitor : Topics.Radical.Observers.AbstractMonitor<Topics.Radical.ComponentModel.Messaging.IMessageBroker>
+    {
+        public MessageBrokerMonitor(Topics.Radical.ComponentModel.Messaging.IMessageBroker broker) { }
+        protected override void OnStopMonitoring(bool targetDisposed) { }
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitFor<TMessage>()
+            where TMessage :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitFor<TMessage>(Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel)
+            where TMessage :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitFor<TMessage>(System.Func<TMessage, bool> filter)
+            where TMessage :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitFor<TMessage>(System.Func<TMessage, bool> filter, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel)
+            where TMessage :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitingFor<TMessage>()
+            where TMessage :  class { }
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitingFor<TMessage>(Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel)
+            where TMessage :  class { }
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitingFor<TMessage>(System.Func<TMessage, bool> filter)
+            where TMessage :  class { }
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitingFor<TMessage>(System.Func<TMessage, bool> filter, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel)
+            where TMessage :  class { }
+    }
+    public class PropertyChangedMonitor : Topics.Radical.Observers.AbstractMonitor
+    {
+        public PropertyChangedMonitor(System.ComponentModel.INotifyPropertyChanged source) { }
+        protected override void OnStopMonitoring(bool targetDisposed) { }
+        protected override void StartMonitoring(object source) { }
+    }
+    public class PropertyChangedMonitor<T> : Topics.Radical.Observers.AbstractMonitor<T>, System.ComponentModel.INotifyPropertyChanged
+        where T : System.ComponentModel.INotifyPropertyChanged
+    {
+        public PropertyChangedMonitor(T source) { }
+        public PropertyChangedMonitor(T source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> Observe(string property) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> Observe<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> property) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> Observe<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> property, System.Action<T, string> callback) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> Observe(string propertyName, System.Action<T, string> callback) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> Observe<TValue>(Topics.Radical.Observable<TValue> property) { }
+        protected virtual void OnPropertyChanged(System.ComponentModel.PropertyChangedEventArgs args) { }
+        protected override void OnStopMonitoring(bool targetDisposed) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> StopObserving<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> property) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> StopObserving<TValue>(Topics.Radical.Observable<TValue> property) { }
+    }
+    public class static PropertyObserver
+    {
+        public static Topics.Radical.Observers.PropertyChangedMonitor<T> For<T>(T source)
+            where T : System.ComponentModel.INotifyPropertyChanged { }
+        public static Topics.Radical.Observers.PropertyChangedMonitor<T> For<T>(T source, Topics.Radical.ComponentModel.IDispatcher dispatcher)
+            where T : System.ComponentModel.INotifyPropertyChanged { }
+        public static Topics.Radical.Observers.PropertyChangedMonitor ForAllPropertiesOf<T>(T source)
+            where T : System.ComponentModel.INotifyPropertyChanged { }
+    }
+}
+namespace Topics.Radical.Reflection
+{
+    
+    public class static AssemblyExtensions
+    {
+        public static T GetAttribute<T>(this System.Reflection.Assembly assembly)
+            where T : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<T> GetAttributes<T>(this System.Reflection.Assembly assembly)
+            where T : System.Attribute { }
+        public static bool IsAttributeDefined<T>(this System.Reflection.Assembly assembly)
+            where T : System.Attribute { }
+        public static bool TryGetAttribute<T>(this System.Reflection.Assembly assembly, out T attribute)
+            where T : System.Attribute { }
+    }
+    public delegate object Function();
+    public class static GetAssembly
+    {
+        public static System.Reflection.Assembly ThatContains<T>() { }
+    }
+    public delegate object LateBoundMethod(object target, object[] arguments);
+    public delegate void LateBoundVoidMethod(object target, object[] arguments);
+    public class static MemberInfoExtensions
+    {
+        public static T GetAttribute<T>(this System.Reflection.MemberInfo memberInfo)
+            where T : System.Attribute { }
+        public static T GetAttribute<T>(this System.Reflection.MemberInfo memberInfo, bool inherit)
+            where T : System.Attribute { }
+        public static T[] GetAttributes<T>(this System.Reflection.MemberInfo memberInfo)
+            where T : System.Attribute { }
+        public static T[] GetAttributes<T>(this System.Reflection.MemberInfo memberInfo, bool inherit)
+            where T : System.Attribute { }
+        public static bool IsAttributeDefined<T>(this System.Reflection.MemberInfo memberInfo)
+            where T : System.Attribute { }
+        public static bool IsAttributeDefined<T>(this System.Reflection.MemberInfo memberInfo, bool inherit)
+            where T : System.Attribute { }
+        public static bool TryGetAttribute<T>(this System.Reflection.MemberInfo memberInfo, out T attribute)
+            where T : System.Attribute { }
+    }
+    public class static MethodInfoExtensions
+    {
+        public static Topics.Radical.Reflection.LateBoundMethod CreateDelegate(this System.Reflection.MethodInfo method) { }
+        public static Topics.Radical.Reflection.LateBoundVoidMethod CreateVoidDelegate(this System.Reflection.MethodInfo method) { }
+    }
+    public class static ObjectExtensions
+    {
+        public static System.Func<T> CreateFastPropertyGetter<T>(this object target, string propertyName) { }
+        public static System.Func<T> CreateFastPropertyGetter<T>(this object target, System.Reflection.PropertyInfo property) { }
+        public static Topics.Radical.Reflection.Function CreateFastPropertyGetter(this object target, System.Reflection.PropertyInfo property) { }
+    }
+    public class static ParameterInfoExtension
+    {
+        public static T GetAttribute<T>(this System.Reflection.ParameterInfo memberInfo)
+            where T : System.Attribute { }
+        public static T[] GetAttributes<T>(this System.Reflection.ParameterInfo memberInfo)
+            where T : System.Attribute { }
+        public static bool IsAttributeDefined<T>(this System.Reflection.ParameterInfo memberInfo)
+            where T : System.Attribute { }
+    }
+    public class static TypeExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Type> GetDescendants(System.Type type) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> GetInheritanceChain(this System.Type type) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> GetInheritanceChain(this System.Type type, System.Func<System.Type, bool> breakIf) { }
+        public static bool Is<T>(this System.Type type) { }
+        public static bool Is(this System.Type type, System.Type otherType) { }
+        public static string ToShortNameString(this System.Type type) { }
+        public static string ToShortString(this System.Type type) { }
+        public static string ToString(this System.Type type, string format) { }
+    }
+}
+namespace Topics.Radical.Threading
+{
+    
+    public class AsyncErrorEventArgs : System.EventArgs
+    {
+        public AsyncErrorEventArgs(System.Exception error) { }
+        public System.Exception Error { get; }
+        public bool Handled { get; set; }
+    }
+    [System.ObsoleteAttribute("Use the Task Parallel Library (TPL) or the new async/await keywords of C# 5.0.", false)]
+    public class static AsyncWorker
+    {
+        public static Topics.Radical.Threading.IOuputWorker<TResult> Expecting<TResult>() { }
+        public static Topics.Radical.Threading.IOuputWorker<TResult> Expecting<TResult>(TResult sample) { }
+        public static Topics.Radical.Threading.IInputWorker<T> Using<T>(T argument) { }
+    }
+    public interface IAfterArgs<T> : Topics.Radical.Threading.IAsyncArgs<T> { }
+    public interface IAfterArgs<T, TResult> : Topics.Radical.Threading.IAfterArgs<T>, Topics.Radical.Threading.IAsyncArgs<T>
+    
+    
+    {
+        TResult Result { get; }
+    }
+    public interface IAsyncArgs<T>
+    
+    {
+        T Argument { get; }
+        bool IsCancellationPending { get; }
+    }
+    public interface IAsyncArgs<T, TResult> : Topics.Radical.Threading.IAsyncArgs<T>
+    
+    
+    {
+        TResult Result { get; set; }
+    }
+    public interface IAsyncErrorArgs
+    {
+        System.Exception Error { get; }
+        bool Handled { get; set; }
+    }
+    public interface IBeforeArgs<T> : Topics.Radical.Threading.ICancelArgs
+    
+    {
+        T Argument { get; }
+    }
+    public interface ICancelArgs
+    {
+        bool Cancel { get; set; }
+    }
+    public interface IConfiguredInputOutputWorker<T, TResult>
+    
+    
+    {
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IAsyncArgs<T, TResult>> asyncAction);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IAsyncArgs<T, TResult>> asyncAction);
+    }
+    public interface IConfiguredInputWorker<T>
+    
+    {
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IAsyncArgs<T>> asyncHandler);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IAsyncArgs<T>> asyncHandler);
+    }
+    public interface IConfiguredOuputWorker<TResult>
+    
+    {
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IOutputAsyncArgs<TResult>> asyncHandler);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IOutputAsyncArgs<TResult>> asyncHandler);
+    }
+    public interface IExecutableWorker : Topics.Radical.Threading.IWorkerStatus
+    {
+        Topics.Radical.Threading.IExecutableWorker AddTrigger(Topics.Radical.ComponentModel.IMonitor trigger);
+        Topics.Radical.Threading.IWorker Execute();
+    }
+    public interface IInputOutputWorker<T, TResult>
+    
+    
+    {
+        Topics.Radical.Threading.IConfiguredInputOutputWorker<T, TResult> Configure(System.Action<Topics.Radical.Threading.IInputOutputWorkerConfiguration<T, TResult>> cfg);
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IAsyncArgs<T, TResult>> asyncAction);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IAsyncArgs<T, TResult>> asyncAction);
+    }
+    public interface IInputOutputWorkerConfiguration<T, TResult> : Topics.Radical.Threading.IWorkerConfiguration
+    
+    
+    {
+        System.Action<Topics.Radical.Threading.IAfterArgs<T, TResult>> After { get; set; }
+        System.Action<Topics.Radical.Threading.IBeforeArgs<T>> Before { get; set; }
+    }
+    public interface IInputWorker<T>
+    
+    {
+        Topics.Radical.Threading.IInputOutputWorker<T, TResult> AndExpecting<TResult>();
+        Topics.Radical.Threading.IInputOutputWorker<T, TResult> AndExpecting<TResult>(TResult sample);
+        Topics.Radical.Threading.IConfiguredInputWorker<T> Configure(System.Action<Topics.Radical.Threading.IInputWorkerConfiguration<T>> cfg);
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IAsyncArgs<T>> asyncHandler);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IAsyncArgs<T>> asyncHandler);
+    }
+    public interface IInputWorkerConfiguration<T> : Topics.Radical.Threading.IWorkerConfiguration
+    
+    {
+        System.Action<Topics.Radical.Threading.IAfterArgs<T>> After { get; set; }
+        System.Action<Topics.Radical.Threading.IBeforeArgs<T>> Before { get; set; }
+    }
+    public interface IOuputWorker<TResult>
+    
+    {
+        Topics.Radical.Threading.IConfiguredOuputWorker<TResult> Configure(System.Action<Topics.Radical.Threading.IOutputWorkerConfiguration<TResult>> cfg);
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IOutputAsyncArgs<TResult>> asyncHandler);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IOutputAsyncArgs<TResult>> asyncHandler);
+    }
+    public interface IOutputAfterArgs<TResult>
+    
+    {
+        TResult Result { get; }
+    }
+    public interface IOutputAsyncArgs<TResult>
+    
+    {
+        TResult Result { get; set; }
+    }
+    public interface IOutputWorkerConfiguration<TResult> : Topics.Radical.Threading.IWorkerConfiguration
+    
+    {
+        System.Action<Topics.Radical.Threading.IOutputAfterArgs<TResult>> After { get; set; }
+        System.Action<Topics.Radical.Threading.ICancelArgs> Before { get; set; }
+    }
+    public interface IWorker : Topics.Radical.Threading.IWorkerStatus
+    {
+        void Cancel();
+    }
+    public interface IWorkerConfiguration
+    {
+        System.Action<Topics.Radical.Threading.IAsyncErrorArgs> Error { get; set; }
+        Topics.Radical.Threading.WarningThreshold WarningThreshold { get; set; }
+    }
+    public interface IWorkerStatus
+    {
+        System.Threading.WaitHandle AsyncWaitHandle { get; }
+        bool HasCompleted { get; }
+        bool IsBusy { get; }
+        public event System.EventHandler<Topics.Radical.Threading.AsyncErrorEventArgs> AsyncError;
+        public event System.EventHandler<Topics.Radical.Threading.WorkCompletedEventArgs> Completed;
+    }
+    public class LimitedConcurrencyLevelTaskScheduler : System.Threading.Tasks.TaskScheduler
+    {
+        public LimitedConcurrencyLevelTaskScheduler(int maxDegreeOfParallelism) { }
+        public virtual int MaximumConcurrencyLevel { get; }
+        protected virtual System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task> GetScheduledTasks() { }
+        protected virtual void QueueTask(System.Threading.Tasks.Task task) { }
+        protected virtual bool TryDequeue(System.Threading.Tasks.Task task) { }
+        protected virtual bool TryExecuteTaskInline(System.Threading.Tasks.Task task, bool taskWasPreviouslyQueued) { }
+    }
+    public sealed class NullDispatcher : Topics.Radical.ComponentModel.IDispatcher
+    {
+        public NullDispatcher() { }
+        public bool IsSafe { get; }
+        public void Dispatch(System.Action action) { }
+        public void Dispatch<T>(T arg, System.Action<T> action) { }
+        public void Dispatch<T1, T2>(T1 arg1, T2 arg2, System.Action<T1, T2> action) { }
+        public TResult Dispatch<TResult>(System.Func<TResult> func) { }
+        public void Invoke(System.Delegate d, params object[] args) { }
+    }
+    public sealed class WarningThreshold
+    {
+        public WarningThreshold() { }
+        public System.Action Handler { get; set; }
+        public System.TimeSpan Threshold { get; set; }
+    }
+    public class WorkCompletedEventArgs : System.EventArgs
+    {
+        public WorkCompletedEventArgs(bool cancelled) { }
+        public bool Cancelled { get; }
+    }
+}
+namespace Topics.Radical.Transactions
+{
+    
+    public sealed class TransactionEnlistmentHelper : System.IDisposable
+    {
+        public TransactionEnlistmentHelper() { }
+        public bool EnlistedInTransaction { get; }
+        public event System.EventHandler TransactionCompleted;
+        public event System.EventHandler TransactionEnlisted;
+        public void Dispose() { }
+        public void EnlistInTransaction(bool ensureTransaction, System.Transactions.IEnlistmentNotification enlistmentNotification, System.Transactions.EnlistmentOptions options) { }
+        protected override void Finalize() { }
+    }
+}
+namespace Topics.Radical.Validation
+{
+    
+    public class static ArrayEnsureExtension
+    {
+        public static Topics.Radical.Validation.IEnsure<T[]> ContainsIndex<T>(this Topics.Radical.Validation.IEnsure<T[]> validator, int index) { }
+    }
+    [System.FlagsAttribute()]
+    public enum Boundary
+    {
+        IncludeLower = 1,
+        ExcludeLower = 2,
+        IncludeHigher = 4,
+        ExcludeHigher = 8,
+        ExcludeBounds = 10,
+        IncludeBounds = 5,
+    }
+    public class static ComparableEnsureExtension
+    {
+        public static Topics.Radical.Validation.IEnsure<T> IsGreaterThen<T>(this Topics.Radical.Validation.IEnsure<T> validator, T expected)
+            where T : System.IComparable<> { }
+        public static Topics.Radical.Validation.IEnsure<T> IsGreaterThen<T>(this Topics.Radical.Validation.IEnsure<T> validator, T expected, Topics.Radical.Validation.Or boundaryBehavior)
+            where T : System.IComparable<> { }
+        public static Topics.Radical.Validation.IEnsure<T> IsSmallerThen<T>(this Topics.Radical.Validation.IEnsure<T> validator, T expected)
+            where T : System.IComparable<> { }
+        public static Topics.Radical.Validation.IEnsure<T> IsSmallerThen<T>(this Topics.Radical.Validation.IEnsure<T> validator, T expected, Topics.Radical.Validation.Or boundaryBehavior)
+            where T : System.IComparable<> { }
+        public static Topics.Radical.Validation.IEnsure<T> IsWithin<T>(this Topics.Radical.Validation.IEnsure<T> validator, T lowerBoundary, T higherBoundary)
+            where T : System.IComparable<> { }
+        public static Topics.Radical.Validation.IEnsure<T> IsWithin<T>(this Topics.Radical.Validation.IEnsure<T> validator, T lowerBoundary, T higherBoundary, Topics.Radical.Validation.Boundary boundaryBehavior)
+            where T : System.IComparable<> { }
+    }
+    public class static Ensure
+    {
+        public static Topics.Radical.Validation.SourceInfoLoadStrategy SourceInfoLoadStrategy { get; set; }
+        public static Topics.Radical.Validation.IConfigurableEnsure<T> That<T>(T obj) { }
+        public static Topics.Radical.Validation.IConfigurableEnsure<T> That<T>(T obj, Topics.Radical.Validation.SourceInfoLoadStrategy strategy) { }
+    }
+    public sealed class Ensure<T> : Topics.Radical.Validation.IConfigurableEnsure<T>, Topics.Radical.Validation.IEnsure<T>
+    
+    {
+        public string Name { get; }
+        public string UserErrorMessage { get; }
+        public T Value { get; }
+        public Topics.Radical.Validation.IEnsure<T> Else(System.Action<T> action) { }
+        public Topics.Radical.Validation.IEnsure<T> Else(System.Action<T, string> action) { }
+        public string GetFullErrorMessage(string validatorSpecificMessage) { }
+        public string GetFullErrorMessage() { }
+        public T GetValue() { }
+        public K GetValue<K>()
+            where K : T { }
+        public Topics.Radical.Validation.IEnsure<T> If(System.Predicate<T> predicate) { }
+        public Topics.Radical.Validation.IEnsure<T> Is(T value) { }
+        public Topics.Radical.Validation.IEnsure<T> IsFalse(System.Predicate<T> func) { }
+        public Topics.Radical.Validation.IEnsure<T> IsNot(T value) { }
+        public Topics.Radical.Validation.IEnsure<T> IsTrue(System.Predicate<T> func) { }
+        public Topics.Radical.Validation.IEnsure<T> Named(string parameterName) { }
+        public Topics.Radical.Validation.IEnsure<T> Named(System.Linq.Expressions.Expression<System.Func<T>> parameterName) { }
+        public Topics.Radical.Validation.IEnsure<T> Then(System.Action<T> action) { }
+        public Topics.Radical.Validation.IEnsure<T> Then(System.Action<T, string> action) { }
+        public Topics.Radical.Validation.IEnsure<T> ThenThrow(System.Func<Topics.Radical.Validation.IEnsure<T>, System.Exception> builder) { }
+        public void Throw(System.Exception error) { }
+        public Topics.Radical.Validation.IEnsure<T> WithMessage(string errorMessage) { }
+        public Topics.Radical.Validation.IEnsure<T> WithMessage(string errorMessage, params object[] formatArgs) { }
+        public Topics.Radical.Validation.IEnsure<T> WithPreview(System.Action<Topics.Radical.Validation.IEnsure<T>, System.Exception> validationFailurePreview) { }
+    }
+    public class static EnsureExtensions
+    {
+        public static Topics.Radical.Validation.IEnsure<T> IsNotNull<T>(this Topics.Radical.Validation.IEnsure<T> validator)
+            where T :  class { }
+    }
+    public class static EnumEnsureExtensions
+    {
+        public static Topics.Radical.Validation.IEnsure<T> IsDefined<T>(this Topics.Radical.Validation.IEnsure<T> validator) { }
+    }
+    public class static GuidEnsureExtension
+    {
+        public static Topics.Radical.Validation.IEnsure<System.Guid> IsNotEmpty(this Topics.Radical.Validation.IEnsure<System.Guid> validator) { }
+    }
+    public interface IConfigurableEnsure<T> : Topics.Radical.Validation.IEnsure<T>
+    
+    {
+        Topics.Radical.Validation.IEnsure<T> Named(System.Linq.Expressions.Expression<System.Func<T>> parameterName);
+        Topics.Radical.Validation.IEnsure<T> Named(string parameterName);
+    }
+    public interface IEnsure<T>
+    
+    {
+        string Name { get; }
+        string UserErrorMessage { get; }
+        T Value { get; }
+        Topics.Radical.Validation.IEnsure<T> Else(System.Action<T, string> action);
+        Topics.Radical.Validation.IEnsure<T> Else(System.Action<T> action);
+        string GetFullErrorMessage(string validatorSpecificMessage);
+        string GetFullErrorMessage();
+        T GetValue();
+        K GetValue<K>()
+            where K : T;
+        Topics.Radical.Validation.IEnsure<T> If(System.Predicate<T> predicate);
+        Topics.Radical.Validation.IEnsure<T> Is(T value);
+        Topics.Radical.Validation.IEnsure<T> IsFalse(System.Predicate<T> func);
+        Topics.Radical.Validation.IEnsure<T> IsNot(T value);
+        Topics.Radical.Validation.IEnsure<T> IsTrue(System.Predicate<T> func);
+        Topics.Radical.Validation.IEnsure<T> Then(System.Action<T, string> action);
+        Topics.Radical.Validation.IEnsure<T> Then(System.Action<T> action);
+        Topics.Radical.Validation.IEnsure<T> ThenThrow(System.Func<Topics.Radical.Validation.IEnsure<T>, System.Exception> builder);
+        void Throw(System.Exception error);
+        Topics.Radical.Validation.IEnsure<T> WithMessage(string errorMessage);
+        Topics.Radical.Validation.IEnsure<T> WithMessage(string errorMessage, params object[] formatArgs);
+        Topics.Radical.Validation.IEnsure<T> WithPreview(System.Action<Topics.Radical.Validation.IEnsure<T>, System.Exception> validationFailurePreview);
+    }
+    public enum Or
+    {
+        Equal = 0,
+        NotEqual = 1,
+    }
+    public enum SourceInfoLoadStrategy
+    {
+        Load = 0,
+        Skip = 1,
+        LazyLoad = 2,
+    }
+    public class static StringEnsureExtension
+    {
+        public static Topics.Radical.Validation.IEnsure<string> IsNotEmpty(this Topics.Radical.Validation.IEnsure<string> validator) { }
+        public static Topics.Radical.Validation.IEnsure<string> IsNotNullNorEmpty(this Topics.Radical.Validation.IEnsure<string> validator) { }
+        public static Topics.Radical.Validation.IEnsure<string> Matches(this Topics.Radical.Validation.IEnsure<string> validator, string regExPattern) { }
+    }
+    public class static TypeEnsureExtension
+    {
+        public static Topics.Radical.Validation.IEnsure<System.Type> Is<T>(this Topics.Radical.Validation.IEnsure<System.Type> validator) { }
+    }
+    public class ValidationContext<T>
+    
+    {
+        public ValidationContext(T entity, Topics.Radical.ComponentModel.Validation.IValidator<T> validator) { }
+        public ValidationContext(T entity, Topics.Radical.ComponentModel.Validation.IValidator<T> validator, Topics.Radical.Validation.ValidationResults results) { }
+        public T Entity { get; }
+        public string PropertyName { get; set; }
+        public Topics.Radical.Validation.ValidationResults Results { get; }
+        public string RuleSet { get; set; }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> Validator { get; }
+    }
+    public class ValidationError
+    {
+        public ValidationError(string key, string keyDisplayName, System.Collections.Generic.IEnumerable<string> detectedProblems) { }
+        public System.Collections.Generic.IEnumerable<string> DetectedProblems { get; }
+        public string Key { get; }
+        public string KeyDisplayName { get; }
+        public void AddProblems(System.Collections.Generic.IEnumerable<string> problems) { }
+        public static Topics.Radical.Validation.ValidationError Create<T>(System.Linq.Expressions.Expression<System.Func<T>> key, string keyDisplayName, params string[] detectedProblems) { }
+        public override string ToString() { }
+    }
+    public class static ValidationErrors
+    {
+        public static readonly System.Collections.Generic.IEnumerable<Topics.Radical.Validation.ValidationError> Empty;
+    }
+    public class ValidationResults
+    {
+        public static readonly Topics.Radical.Validation.ValidationResults Empty;
+        public ValidationResults() { }
+        public ValidationResults(System.Collections.Generic.IEnumerable<Topics.Radical.Validation.ValidationError> errors) { }
+        public System.Collections.Generic.IEnumerable<Topics.Radical.Validation.ValidationError> Errors { get; }
+        public bool IsValid { get; }
+        [System.ObsoleteAttribute("Use the overload without the evil \'params\' keyword using an explicit array: new[]" +
+            " { \'your error text here\' }.", true)]
+        public void AddError<T>(System.Linq.Expressions.Expression<System.Func<T>> key, params string[] detectedProblems) { }
+        public void AddError<T>(System.Linq.Expressions.Expression<System.Func<T>> key, string displayName, string[] detectedProblems) { }
+        public void AddError(Topics.Radical.Validation.ValidationError error) { }
+        public override string ToString() { }
+    }
+    public class ValidationTools
+    {
+        public ValidationTools() { }
+        public string GetPropertyDisplayName(string propertyName, object entity) { }
+    }
+    public class ValidatorBase<T> : Topics.Radical.ComponentModel.Validation.IValidator, Topics.Radical.ComponentModel.Validation.IValidator<T>
+    
+    {
+        public ValidatorBase(string ruleSet) { }
+        public string RuleSet { get; }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Action<Topics.Radical.Validation.ValidationContext<T>> rule) { }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Linq.Expressions.Expression<System.Func<T, object>> propertyIdentifier, System.Func<Topics.Radical.Validation.ValidationContext<T>, Topics.Radical.ComponentModel.Validation.RuleEvaluation> rule, string error) { }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Linq.Expressions.Expression<System.Func<T, object>> propertyIdentifier, System.Func<Topics.Radical.Validation.ValidationContext<T>, Topics.Radical.ComponentModel.Validation.RuleEvaluation> rule, System.Func<Topics.Radical.Validation.ValidationContext<T>, string> error) { }
+        protected virtual string GetPropertyDisplayName(string propertyName, object entity) { }
+        public bool IsValid(T entity) { }
+        protected virtual void OnValidate(Topics.Radical.Validation.ValidationContext<T> context) { }
+        public Topics.Radical.Validation.ValidationResults Validate(T entity) { }
+        public Topics.Radical.Validation.ValidationResults Validate(T entity, string propertyName) { }
+        public Topics.Radical.Validation.ValidationResults Validate<TProperty>(T entity, System.Linq.Expressions.Expression<System.Func<T, TProperty>> property) { }
+    }
+    public sealed class ValidatorBaseFactory : Topics.Radical.ComponentModel.Validation.IValidatorFactory
+    {
+        public ValidatorBaseFactory() { }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> CreateValidator<T>() { }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> CreateValidator<T>(string ruleSet) { }
+    }
+}
+namespace Topics.Radical.Win32
+{
+    
+    public class static Constants
+    {
+        public const int ACM_OPENA = 1124;
+        public const int ACM_OPENW = 1127;
+        public const int ADVF_NODATA = 1;
+        public const int ADVF_ONLYONCE = 2;
+        public const int ADVF_PRIMEFIRST = 4;
+        public const int ARW_BOTTOMLEFT = 0;
+        public const int ARW_BOTTOMRIGHT = 1;
+        public const int ARW_DOWN = 4;
+        public const int ARW_HIDE = 8;
+        public const int ARW_LEFT = 0;
+        public const int ARW_RIGHT = 0;
+        public const int ARW_TOPLEFT = 2;
+        public const int ARW_TOPRIGHT = 3;
+        public const int ARW_UP = 4;
+        public const int AUTOAPPEND = 1073741824;
+        public const int AUTOAPPEND_OFF = -2147483648;
+        public const int AUTOSUGGEST = 268435456;
+        public const int AUTOSUGGEST_OFF = 536870912;
+        public const int BCM_GETIDEALSIZE = 5633;
+        public const int BDR_RAISED = 5;
+        public const int BDR_RAISEDINNER = 4;
+        public const int BDR_RAISEDOUTER = 1;
+        public const int BDR_SUNKEN = 10;
+        public const int BDR_SUNKENINNER = 8;
+        public const int BDR_SUNKENOUTER = 2;
+        public const int BF_ADJUST = 8192;
+        public const int BF_BOTTOM = 8;
+        public const int BF_FLAT = 16384;
+        public const int BF_LEFT = 1;
+        public const int BF_MIDDLE = 2048;
+        public const int BF_RIGHT = 4;
+        public const int BF_TOP = 2;
+        public const int BFFM_ENABLEOK = 1125;
+        public const int BFFM_INITIALIZED = 1;
+        public const int BFFM_SELCHANGED = 2;
+        public const int BFFM_SETSELECTION = 1127;
+        public const int BI_RGB = 0;
+        public const int BITSPIXEL = 12;
+        public const int BM_CLICK = 245;
+        public const int BM_SETCHECK = 241;
+        public const int BM_SETSTATE = 243;
+        public const int BN_CLICKED = 0;
+        public const int BS_3STATE = 5;
+        public const int BS_BOTTOM = 2048;
+        public const int BS_CENTER = 768;
+        public const int BS_DEFPUSHBUTTON = 1;
+        public const int BS_GROUPBOX = 7;
+        public const int BS_LEFT = 256;
+        public const int BS_MULTILINE = 8192;
+        public const int BS_OWNERDRAW = 11;
+        public const int BS_PATTERN = 3;
+        public const int BS_PUSHBUTTON = 0;
+        public const int BS_PUSHLIKE = 4096;
+        public const int BS_RADIOBUTTON = 4;
+        public const int BS_RIGHT = 512;
+        public const int BS_RIGHTBUTTON = 32;
+        public const int BS_TOP = 1024;
+        public const int BS_VCENTER = 3072;
+        public const int CB_ADDSTRING = 323;
+        public const int CB_DELETESTRING = 324;
+        public const int CB_ERR = -1;
+        public const int CB_FINDSTRING = 332;
+        public const int CB_FINDSTRINGEXACT = 344;
+        public const int CB_GETCURSEL = 327;
+        public const int CB_GETDROPPEDSTATE = 343;
+        public const int CB_GETEDITSEL = 320;
+        public const int CB_GETITEMDATA = 336;
+        public const int CB_GETITEMHEIGHT = 340;
+        public const int CB_INSERTSTRING = 330;
+        public const int CB_LIMITTEXT = 321;
+        public const int CB_RESETCONTENT = 331;
+        public const int CB_SETCURSEL = 334;
+        public const int CB_SETDROPPEDWIDTH = 352;
+        public const int CB_SETEDITSEL = 322;
+        public const int CB_SETITEMHEIGHT = 339;
+        public const int CB_SHOWDROPDOWN = 335;
+        public const int CBEM_GETITEMA = 1028;
+        public const int CBEM_GETITEMW = 1037;
+        public const int CBEM_INSERTITEMA = 1025;
+        public const int CBEM_INSERTITEMW = 1035;
+        public const int CBEM_SETITEMA = 1029;
+        public const int CBEM_SETITEMW = 1036;
+        public const int CBEN_ENDEDITA = -805;
+        public const int CBEN_ENDEDITW = -806;
+        public const int CBN_CLOSEUP = 8;
+        public const int CBN_DBLCLK = 2;
+        public const int CBN_DROPDOWN = 7;
+        public const int CBN_EDITCHANGE = 5;
+        public const int CBN_EDITUPDATE = 6;
+        public const int CBN_SELCHANGE = 1;
+        public const int CBN_SELENDOK = 9;
+        public const int CBS_AUTOHSCROLL = 64;
+        public const int CBS_DROPDOWN = 2;
+        public const int CBS_DROPDOWNLIST = 3;
+        public const int CBS_HASSTRINGS = 512;
+        public const int CBS_NOINTEGRALHEIGHT = 1024;
+        public const int CBS_OWNERDRAWFIXED = 16;
+        public const int CBS_OWNERDRAWVARIABLE = 32;
+        public const int CBS_SIMPLE = 1;
+        public const int CC_ANYCOLOR = 256;
+        public const int CC_ENABLEHOOK = 16;
+        public const int CC_FULLOPEN = 2;
+        public const int CC_PREVENTFULLOPEN = 4;
+        public const int CC_RGBINIT = 1;
+        public const int CC_SHOWHELP = 8;
+        public const int CC_SOLIDCOLOR = 128;
+        public const int CCS_NODIVIDER = 64;
+        public const int CCS_NOPARENTALIGN = 8;
+        public const int CCS_NORESIZE = 4;
+        public const int CDDS_ITEM = 65536;
+        public const int CDDS_ITEMPOSTPAINT = 65538;
+        public const int CDDS_ITEMPREPAINT = 65537;
+        public const int CDDS_POSTPAINT = 2;
+        public const int CDDS_PREPAINT = 1;
+        public const int CDDS_SUBITEM = 131072;
+        public const int CDERR_DIALOGFAILURE = 65535;
+        public const int CDERR_FINDRESFAILURE = 6;
+        public const int CDERR_INITIALIZATION = 2;
+        public const int CDERR_LOADRESFAILURE = 7;
+        public const int CDERR_LOADSTRFAILURE = 5;
+        public const int CDERR_LOCKRESFAILURE = 8;
+        public const int CDERR_MEMALLOCFAILURE = 9;
+        public const int CDERR_MEMLOCKFAILURE = 10;
+        public const int CDERR_NOHINSTANCE = 4;
+        public const int CDERR_NOHOOK = 11;
+        public const int CDERR_NOTEMPLATE = 3;
+        public const int CDERR_REGISTERMSGFAIL = 12;
+        public const int CDERR_STRUCTSIZE = 1;
+        public const int CDIS_CHECKED = 8;
+        public const int CDIS_DEFAULT = 32;
+        public const int CDIS_DISABLED = 4;
+        public const int CDIS_FOCUS = 16;
+        public const int CDIS_GRAYED = 2;
+        public const int CDIS_HOT = 64;
+        public const int CDIS_INDETERMINATE = 256;
+        public const int CDIS_MARKED = 128;
+        public const int CDIS_SELECTED = 1;
+        public const int CDIS_SHOWKEYBOARDCUES = 512;
+        public const int CDRF_DODEFAULT = 0;
+        public const int CDRF_NEWFONT = 2;
+        public const int CDRF_NOTIFYITEMDRAW = 32;
+        public const int CDRF_NOTIFYPOSTPAINT = 16;
+        public const int CDRF_NOTIFYSUBITEMDRAW = 32;
+        public const int CDRF_SKIPDEFAULT = 4;
+        public const int CF_APPLY = 512;
+        public const int CF_BITMAP = 2;
+        public const int CF_DIB = 8;
+        public const int CF_DIF = 5;
+        public const int CF_EFFECTS = 256;
+        public const int CF_ENABLEHOOK = 8;
+        public const int CF_ENHMETAFILE = 14;
+        public const int CF_FIXEDPITCHONLY = 16384;
+        public const int CF_FORCEFONTEXIST = 65536;
+        public const int CF_HDROP = 15;
+        public const int CF_INITTOLOGFONTSTRUCT = 64;
+        public const int CF_LIMITSIZE = 8192;
+        public const int CF_LOCALE = 16;
+        public const int CF_METAFILEPICT = 3;
+        public const int CF_NOSIMULATIONS = 4096;
+        public const int CF_NOVECTORFONTS = 2048;
+        public const int CF_NOVERTFONTS = 16777216;
+        public const int CF_OEMTEXT = 7;
+        public const int CF_PALETTE = 9;
+        public const int CF_PENDATA = 10;
+        public const int CF_RIFF = 11;
+        public const int CF_SCREENFONTS = 1;
+        public const int CF_SCRIPTSONLY = 1024;
+        public const int CF_SELECTSCRIPT = 4194304;
+        public const int CF_SHOWHELP = 4;
+        public const int CF_SYLK = 4;
+        public const int CF_TEXT = 1;
+        public const int CF_TIFF = 6;
+        public const int CF_TTONLY = 262144;
+        public const int CF_UNICODETEXT = 13;
+        public const int CF_WAVE = 12;
+        public const int CFERR_MAXLESSTHANMIN = 8194;
+        public const int CFERR_NOFONTS = 8193;
+        public const int CLR_DEFAULT = -16777216;
+        public const int CLR_NONE = -1;
+        public const int CLSCTX_INPROC_SERVER = 1;
+        public const int CLSCTX_LOCAL_SERVER = 4;
+        public const int cmb4 = 1139;
+        public const int COLOR_WINDOW = 5;
+        public const int CONNECT_E_CANNOTCONNECT = -2147220990;
+        public const int CONNECT_E_NOCONNECTION = -2147220992;
+        public const int CP_WINANSI = 1004;
+        public const int CS_DBLCLKS = 8;
+        public const int CS_DROPSHADOW = 131072;
+        public const int CSC_NAVIGATEBACK = 2;
+        public const int CSC_NAVIGATEFORWARD = 1;
+        public const int CSIDL_APPDATA = 26;
+        public const int CSIDL_COMMON_APPDATA = 35;
+        public const int CSIDL_COOKIES = 33;
+        public const int CSIDL_DESKTOP = 0;
+        public const int CSIDL_DESKTOPDIRECTORY = 16;
+        public const int CSIDL_FAVORITES = 6;
+        public const int CSIDL_HISTORY = 34;
+        public const int CSIDL_INTERNET = 1;
+        public const int CSIDL_INTERNET_CACHE = 32;
+        public const int CSIDL_LOCAL_APPDATA = 28;
+        public const int CSIDL_PERSONAL = 5;
+        public const int CSIDL_PROGRAM_FILES = 38;
+        public const int CSIDL_PROGRAM_FILES_COMMON = 43;
+        public const int CSIDL_PROGRAMS = 2;
+        public const int CSIDL_RECENT = 8;
+        public const int CSIDL_SENDTO = 9;
+        public const int CSIDL_STARTMENU = 11;
+        public const int CSIDL_STARTUP = 7;
+        public const int CSIDL_SYSTEM = 37;
+        public const int CSIDL_TEMPLATES = 21;
+        public const int CTRLINFO_EATS_ESCAPE = 2;
+        public const int CTRLINFO_EATS_RETURN = 1;
+        public const int CW_USEDEFAULT = -2147483648;
+        public const int CWP_SKIPINVISIBLE = 1;
+        public const int DCX_CACHE = 2;
+        public const int DCX_LOCKWINDOWUPDATE = 1024;
+        public const int DCX_WINDOW = 1;
+        public const int DEFAULT_GUI_FONT = 17;
+        public const int DFC_BUTTON = 4;
+        public const int DFC_CAPTION = 1;
+        public const int DFC_MENU = 2;
+        public const int DFC_SCROLL = 3;
+        public const int DFCS_BUTTON3STATE = 8;
+        public const int DFCS_BUTTONCHECK = 0;
+        public const int DFCS_BUTTONPUSH = 16;
+        public const int DFCS_BUTTONRADIO = 4;
+        public const int DFCS_CAPTIONCLOSE = 0;
+        public const int DFCS_CAPTIONHELP = 4;
+        public const int DFCS_CAPTIONMAX = 2;
+        public const int DFCS_CAPTIONMIN = 1;
+        public const int DFCS_CAPTIONRESTORE = 3;
+        public const int DFCS_CHECKED = 1024;
+        public const int DFCS_FLAT = 16384;
+        public const int DFCS_INACTIVE = 256;
+        public const int DFCS_MENUARROW = 0;
+        public const int DFCS_MENUBULLET = 2;
+        public const int DFCS_MENUCHECK = 1;
+        public const int DFCS_PUSHED = 512;
+        public const int DFCS_SCROLLCOMBOBOX = 5;
+        public const int DFCS_SCROLLDOWN = 1;
+        public const int DFCS_SCROLLLEFT = 2;
+        public const int DFCS_SCROLLRIGHT = 3;
+        public const int DFCS_SCROLLUP = 0;
+        public const int DI_NORMAL = 3;
+        public const int DIB_RGB_COLORS = 0;
+        public const int DISP_E_EXCEPTION = -2147352567;
+        public const int DISP_E_MEMBERNOTFOUND = -2147352573;
+        public const int DISP_E_PARAMNOTFOUND = -2147352572;
+        public const int DISPATCH_METHOD = 1;
+        public const int DISPATCH_PROPERTYGET = 2;
+        public const int DISPATCH_PROPERTYPUT = 4;
+        public const int DISPID_PROPERTYPUT = -3;
+        public const int DISPID_UNKNOWN = -1;
+        public const int DLGC_WANTALLKEYS = 4;
+        public const int DLGC_WANTARROWS = 1;
+        public const int DLGC_WANTCHARS = 128;
+        public const int DLGC_WANTTAB = 2;
+        public const int DRAGDROP_E_ALREADYREGISTERED = -2147221247;
+        public const int DRAGDROP_E_NOTREGISTERED = -2147221248;
+        public const int DT_CALCRECT = 1024;
+        public const int DT_EDITCONTROL = 8192;
+        public const int DT_END_ELLIPSIS = 32768;
+        public const int DT_EXPANDTABS = 64;
+        public const int DT_LEFT = 0;
+        public const int DT_NOCLIP = 256;
+        public const int DT_NOPREFIX = 2048;
+        public const int DT_RIGHT = 2;
+        public const int DT_RTLREADING = 131072;
+        public const int DT_SINGLELINE = 32;
+        public const int DT_VCENTER = 4;
+        public const int DT_WORDBREAK = 16;
+        public const int DTM_SETFORMATA = 4101;
+        public const int DTM_SETFORMATW = 4146;
+        public const int DTM_SETMCCOLOR = 4102;
+        public const int DTM_SETMCFONT = 4105;
+        public const int DTM_SETRANGE = 4100;
+        public const int DTM_SETSYSTEMTIME = 4098;
+        public const int DTN_CLOSEUP = -753;
+        public const int DTN_DATETIMECHANGE = -759;
+        public const int DTN_DROPDOWN = -754;
+        public const int DTN_FORMATA = -756;
+        public const int DTN_FORMATQUERYA = -755;
+        public const int DTN_FORMATQUERYW = -742;
+        public const int DTN_FORMATW = -743;
+        public const int DTN_USERSTRINGA = -758;
+        public const int DTN_USERSTRINGW = -745;
+        public const int DTN_WMKEYDOWNA = -757;
+        public const int DTN_WMKEYDOWNW = -744;
+        public const int DTS_LONGDATEFORMAT = 4;
+        public const int DTS_RIGHTALIGN = 32;
+        public const int DTS_SHOWNONE = 2;
+        public const int DTS_TIMEFORMAT = 9;
+        public const int DTS_UPDOWN = 1;
+        public const int DUPLICATE = 6;
+        public const int DUPLICATE_SAME_ACCESS = 2;
+        public const int DV_E_DVASPECT = -2147221397;
+        public const int DVASPECT_CONTENT = 1;
+        public const int DVASPECT_OPAQUE = 16;
+        public const int DVASPECT_TRANSPARENT = 32;
+        public const int E_ABORT = -2147467260;
+        public const int E_FAIL = -2147467259;
+        public const int E_INVALIDARG = -2147024809;
+        public const int E_NOINTERFACE = -2147467262;
+        public const int E_NOTIMPL = -2147467263;
+        public const int E_OUTOFMEMORY = -2147024882;
+        public const int E_UNEXPECTED = -2147418113;
+        public const int EC_LEFTMARGIN = 1;
+        public const int EC_RIGHTMARGIN = 2;
+        public const int ECM_FIRST = 5376;
+        public const int EDGE_BUMP = 9;
+        public const int EDGE_ETCHED = 6;
+        public const int EDGE_RAISED = 5;
+        public const int EDGE_SUNKEN = 10;
+        public const int EM_CANUNDO = 198;
+        public const int EM_CHARFROMPOS = 215;
+        public const int EM_EMPTYUNDOBUFFER = 205;
+        public const int EM_GETLINE = 196;
+        public const int EM_GETLINECOUNT = 186;
+        public const int EM_GETMODIFY = 184;
+        public const int EM_GETPASSWORDCHAR = 210;
+        public const int EM_GETSEL = 176;
+        public const int EM_LIMITTEXT = 197;
+        public const int EM_LINEFROMCHAR = 201;
+        public const int EM_LINEINDEX = 187;
+        public const int EM_POSFROMCHAR = 214;
+        public const int EM_REPLACESEL = 194;
+        public const int EM_SCROLL = 181;
+        public const int EM_SCROLLCARET = 183;
+        public const int EM_SETCUEBANNER = 5377;
+        public const int EM_SETMARGINS = 211;
+        public const int EM_SETMODIFY = 185;
+        public const int EM_SETPASSWORDCHAR = 204;
+        public const int EM_SETREADONLY = 207;
+        public const int EM_SETSEL = 177;
+        public const int EM_UNDO = 199;
+        public const int EMR_POLYTEXTOUTA = 96;
+        public const int EMR_POLYTEXTOUTW = 97;
+        public const int EN_ALIGN_LTR_EC = 1792;
+        public const int EN_ALIGN_RTL_EC = 1793;
+        public const int EN_CHANGE = 768;
+        public const int EN_HSCROLL = 1537;
+        public const int EN_VSCROLL = 1538;
+        public const int ES_AUTOHSCROLL = 128;
+        public const int ES_AUTOVSCROLL = 64;
+        public const int ES_CENTER = 1;
+        public const int ES_LEFT = 0;
+        public const int ES_LOWERCASE = 16;
+        public const int ES_MULTILINE = 4;
+        public const int ES_NOHIDESEL = 256;
+        public const int ES_NUMBER = 8192;
+        public const int ES_PASSWORD = 32;
+        public const int ES_READONLY = 2048;
+        public const int ES_RIGHT = 2;
+        public const int ES_UPPERCASE = 8;
+        public const int ETO_CLIPPED = 4;
+        public const int ETO_OPAQUE = 2;
+        public const int FADF_BSTR = 256;
+        public const int FADF_DISPATCH = 1024;
+        public const int FADF_UNKNOWN = 512;
+        public const int FADF_VARIANT = 2048;
+        public const int FALT = 16;
+        public const int FLASHW_ALL = 3;
+        public const int FLASHW_CAPTION = 1;
+        public const int FLASHW_STOP = 0;
+        public const int FLASHW_TIMER = 4;
+        public const int FLASHW_TIMERNOFG = 12;
+        public const int FLASHW_TRAY = 2;
+        public const int FNERR_BUFFERTOOSMALL = 12291;
+        public const int FNERR_INVALIDFILENAME = 12290;
+        public const int FNERR_SUBCLASSFAILURE = 12289;
+        public const int FORMAT_MESSAGE_FROM_SYSTEM = 4096;
+        public const int FORMAT_MESSAGE_IGNORE_INSERTS = 512;
+        public const int FRERR_BUFFERLENGTHZERO = 16385;
+        public const int FSHIFT = 4;
+        public const int FVIRTKEY = 1;
+        public const int GDI_ERROR = -1;
+        public const int GDT_NONE = 1;
+        public const int GDT_VALID = 0;
+        public const int GDTR_MAX = 2;
+        public const int GDTR_MIN = 1;
+        public const int GMEM_DDESHARE = 8192;
+        public const int GMEM_MOVEABLE = 2;
+        public const int GMEM_ZEROINIT = 64;
+        public const int GMR_DAYSTATE = 1;
+        public const int GMR_VISIBLE = 0;
+        public const int GW_CHILD = 5;
+        public const int GW_HWNDFIRST = 0;
+        public const int GW_HWNDLAST = 1;
+        public const int GW_HWNDNEXT = 2;
+        public const int GW_HWNDPREV = 3;
+        public const int GWL_EXSTYLE = -20;
+        public const int GWL_HWNDPARENT = -8;
+        public const int GWL_ID = -12;
+        public const int GWL_STYLE = -16;
+        public const int GWL_WNDPROC = -4;
+        public const int HC_ACTION = 0;
+        public const int HC_GETNEXT = 1;
+        public const int HC_SKIP = 2;
+        public const int HCF_HIGHCONTRASTON = 1;
+        public const int HDI_ORDER = 128;
+        public const int HDM_GETITEMA = 4611;
+        public const int HDM_GETITEMCOUNT = 4608;
+        public const int HDM_GETITEMW = 4619;
+        public const int HDM_INSERTITEMA = 4609;
+        public const int HDM_INSERTITEMW = 4618;
+        public const int HDM_SETITEMA = 4612;
+        public const int HDM_SETITEMW = 4620;
+        public const int HDN_BEGINTDRAG = -310;
+        public const int HDN_BEGINTRACKA = -306;
+        public const int HDN_BEGINTRACKW = -326;
+        public const int HDN_DIVIDERDBLCLICKA = -305;
+        public const int HDN_DIVIDERDBLCLICKW = -325;
+        public const int HDN_ENDDRAG = -311;
+        public const int HDN_ENDTRACKA = -307;
+        public const int HDN_ENDTRACKW = -327;
+        public const int HDN_GETDISPINFOA = -309;
+        public const int HDN_GETDISPINFOW = -329;
+        public const int HDN_ITEMCHANGEDA = -301;
+        public const int HDN_ITEMCHANGEDW = -321;
+        public const int HDN_ITEMCHANGINGA = -300;
+        public const int HDN_ITEMCHANGINGW = -320;
+        public const int HDN_ITEMCLICKA = -302;
+        public const int HDN_ITEMCLICKW = -322;
+        public const int HDN_ITEMDBLCLICKA = -303;
+        public const int HDN_ITEMDBLCLICKW = -323;
+        public const int HDN_TRACKA = -308;
+        public const int HDN_TRACKW = -328;
+        public const int HELPINFO_WINDOW = 1;
+        public const int HLP_FILE = 1;
+        public const int HLP_KEYWORD = 2;
+        public const int HLP_NAVIGATOR = 3;
+        public const int HLP_OBJECT = 4;
+        public const int HOLLOW_BRUSH = 5;
+        public const int HTBOTTOM = 15;
+        public const int HTBOTTOMRIGHT = 17;
+        public const int HTCAPTION = 2;
+        public const int HTCLIENT = 1;
+        public const int HTNOWHERE = 0;
+        public const int HTTRANSPARENT = -1;
+        public const int ICC_BAR_CLASSES = 4;
+        public const int ICC_DATE_CLASSES = 256;
+        public const int ICC_LISTVIEW_CLASSES = 1;
+        public const int ICC_PROGRESS_CLASS = 32;
+        public const int ICC_TAB_CLASSES = 8;
+        public const int ICC_TREEVIEW_CLASSES = 2;
+        public const int ICON_BIG = 1;
+        public const int ICON_SMALL = 0;
+        public const int IDC_APPSTARTING = 32650;
+        public const int IDC_ARROW = 32512;
+        public const int IDC_CROSS = 32515;
+        public const int IDC_HELP = 32651;
+        public const int IDC_IBEAM = 32513;
+        public const int IDC_NO = 32648;
+        public const int IDC_SIZEALL = 32646;
+        public const int IDC_SIZENESW = 32643;
+        public const int IDC_SIZENS = 32645;
+        public const int IDC_SIZENWSE = 32642;
+        public const int IDC_SIZEWE = 32644;
+        public const int IDC_UPARROW = 32516;
+        public const int IDC_WAIT = 32514;
+        public const int IDM_PAGESETUP = 2004;
+        public const int IDM_PRINT = 27;
+        public const int IDM_PRINTPREVIEW = 2003;
+        public const int IDM_PROPERTIES = 28;
+        public const int IDM_SAVEAS = 71;
+        public const int ILC_COLOR = 0;
+        public const int ILC_COLOR16 = 16;
+        public const int ILC_COLOR24 = 24;
+        public const int ILC_COLOR32 = 32;
+        public const int ILC_COLOR4 = 4;
+        public const int ILC_COLOR8 = 8;
+        public const int ILC_MASK = 1;
+        public const int ILD_MASK = 16;
+        public const int ILD_NORMAL = 0;
+        public const int ILD_ROP = 64;
+        public const int ILD_TRANSPARENT = 1;
+        public const int ILS_ALPHA = 8;
+        public const int ILS_GLOW = 1;
+        public const int ILS_NORMAL = 0;
+        public const int ILS_SATURATE = 4;
+        public const int ILS_SHADOW = 2;
+        public const int IMAGE_CURSOR = 2;
+        public const int IMAGE_ICON = 1;
+        public const int IME_CMODE_FULLSHAPE = 8;
+        public const int IME_CMODE_KATAKANA = 2;
+        public const int IME_CMODE_NATIVE = 1;
+        public const int INET_E_DEFAULT_ACTION = -2146697199;
+        public const int INPLACE_E_NOTOOLSPACE = -2147221087;
+        public const int KEYEVENTF_KEYUP = 2;
+        public const int LANG_NEUTRAL = 0;
+        public const int LB_ADDSTRING = 384;
+        public const int LB_DELETESTRING = 386;
+        public const int LB_ERR = -1;
+        public const int LB_ERRSPACE = -2;
+        public const int LB_FINDSTRING = 399;
+        public const int LB_FINDSTRINGEXACT = 418;
+        public const int LB_GETCARETINDEX = 415;
+        public const int LB_GETCURSEL = 392;
+        public const int LB_GETITEMHEIGHT = 417;
+        public const int LB_GETITEMRECT = 408;
+        public const int LB_GETSEL = 391;
+        public const int LB_GETSELCOUNT = 400;
+        public const int LB_GETSELITEMS = 401;
+        public const int LB_GETTEXT = 393;
+        public const int LB_GETTEXTLEN = 394;
+        public const int LB_GETTOPINDEX = 398;
+        public const int LB_INSERTSTRING = 385;
+        public const int LB_ITEMFROMPOINT = 425;
+        public const int LB_RESETCONTENT = 388;
+        public const int LB_SETCOLUMNWIDTH = 405;
+        public const int LB_SETCURSEL = 390;
+        public const int LB_SETHORIZONTALEXTENT = 404;
+        public const int LB_SETITEMHEIGHT = 416;
+        public const int LB_SETLOCALE = 421;
+        public const int LB_SETSEL = 389;
+        public const int LB_SETTABSTOPS = 402;
+        public const int LB_SETTOPINDEX = 407;
+        public const int LBN_DBLCLK = 2;
+        public const int LBN_SELCHANGE = 1;
+        public const int LBS_DISABLENOSCROLL = 4096;
+        public const int LBS_EXTENDEDSEL = 2048;
+        public const int LBS_HASSTRINGS = 64;
+        public const int LBS_MULTICOLUMN = 512;
+        public const int LBS_MULTIPLESEL = 8;
+        public const int LBS_NOINTEGRALHEIGHT = 256;
+        public const int LBS_NOSEL = 16384;
+        public const int LBS_NOTIFY = 1;
+        public const int LBS_OWNERDRAWFIXED = 16;
+        public const int LBS_OWNERDRAWVARIABLE = 32;
+        public const int LBS_USETABSTOPS = 128;
+        public const int LBS_WANTKEYBOARDINPUT = 1024;
+        public const int LLKHF_ALTDOWN = 32;
+        public const int LLKHF_EXTENDED = 1;
+        public const int LLKHF_INJECTED = 16;
+        public const int LLKHF_UP = 128;
+        public const int LOCALE_IFIRSTDAYOFWEEK = 4108;
+        public const int LOCK_EXCLUSIVE = 2;
+        public const int LOCK_ONLYONCE = 4;
+        public const int LOCK_WRITE = 1;
+        public const int LOGPIXELSX = 88;
+        public const int LOGPIXELSY = 90;
+        public const int LV_VIEW_TILE = 4;
+        public const int LVA_ALIGNLEFT = 1;
+        public const int LVA_ALIGNTOP = 2;
+        public const int LVA_DEFAULT = 0;
+        public const int LVA_SNAPTOGRID = 5;
+        public const int LVBKIF_SOURCE_NONE = 0;
+        public const int LVBKIF_SOURCE_URL = 2;
+        public const int LVBKIF_STYLE_NORMAL = 0;
+        public const int LVBKIF_STYLE_TILE = 16;
+        public const int LVCDI_ITEM = 0;
+        public const int LVCF_FMT = 1;
+        public const int LVCF_IMAGE = 16;
+        public const int LVCF_ORDER = 32;
+        public const int LVCF_SUBITEM = 8;
+        public const int LVCF_TEXT = 4;
+        public const int LVCF_WIDTH = 2;
+        public const int LVFI_NEARESTXY = 64;
+        public const int LVFI_PARAM = 1;
+        public const int LVFI_PARTIAL = 8;
+        public const int LVFI_STRING = 2;
+        public const int LVGA_FOOTER_CENTER = 16;
+        public const int LVGA_FOOTER_LEFT = 8;
+        public const int LVGA_FOOTER_RIGHT = 32;
+        public const int LVGA_HEADER_CENTER = 2;
+        public const int LVGA_HEADER_LEFT = 1;
+        public const int LVGA_HEADER_RIGHT = 4;
+        public const int LVGF_ALIGN = 8;
+        public const int LVGF_FOOTER = 2;
+        public const int LVGF_GROUPID = 16;
+        public const int LVGF_HEADER = 1;
+        public const int LVGF_NONE = 0;
+        public const int LVGF_STATE = 4;
+        public const int LVGS_COLLAPSED = 1;
+        public const int LVGS_HIDDEN = 2;
+        public const int LVGS_NORMAL = 0;
+        public const int LVHT_ABOVE = 8;
+        public const int LVHT_BELOW = 16;
+        public const int LVHT_LEFT = 64;
+        public const int LVHT_NOWHERE = 1;
+        public const int LVHT_ONITEM = 14;
+        public const int LVHT_ONITEMICON = 2;
+        public const int LVHT_ONITEMLABEL = 4;
+        public const int LVHT_ONITEMSTATEICON = 8;
+        public const int LVHT_RIGHT = 32;
+        public const int LVIF_COLUMNS = 512;
+        public const int LVIF_GROUPID = 256;
+        public const int LVIF_IMAGE = 2;
+        public const int LVIF_INDENT = 16;
+        public const int LVIF_PARAM = 4;
+        public const int LVIF_STATE = 8;
+        public const int LVIF_TEXT = 1;
+        public const int LVIM_AFTER = 1;
+        public const int LVIR_BOUNDS = 0;
+        public const int LVIR_ICON = 1;
+        public const int LVIR_LABEL = 2;
+        public const int LVIR_SELECTBOUNDS = 3;
+        public const int LVIS_CUT = 4;
+        public const int LVIS_DROPHILITED = 8;
+        public const int LVIS_FOCUSED = 1;
+        public const int LVIS_OVERLAYMASK = 3840;
+        public const int LVIS_SELECTED = 2;
+        public const int LVIS_STATEIMAGEMASK = 61440;
+        public const int LVM_ARRANGE = 4118;
+        public const int LVM_DELETEALLITEMS = 4105;
+        public const int LVM_DELETECOLUMN = 4124;
+        public const int LVM_DELETEITEM = 4104;
+        public const int LVM_EDITLABELA = 4119;
+        public const int LVM_EDITLABELW = 4214;
+        public const int LVM_ENABLEGROUPVIEW = 4253;
+        public const int LVM_ENSUREVISIBLE = 4115;
+        public const int LVM_FINDITEMA = 4109;
+        public const int LVM_FINDITEMW = 4179;
+        public const int LVM_FIRST = 4096;
+        public const int LVM_GETCOLUMNA = 4121;
+        public const int LVM_GETCOLUMNW = 4191;
+        public const int LVM_GETCOLUMNWIDTH = 4125;
+        public const int LVM_GETGROUPINFO = 4245;
+        public const int LVM_GETHEADER = 4127;
+        public const int LVM_GETHOTITEM = 4157;
+        public const int LVM_GETINSERTMARK = 4263;
+        public const int LVM_GETINSERTMARKCOLOR = 4267;
+        public const int LVM_GETINSERTMARKRECT = 4265;
+        public const int LVM_GETISEARCHSTRINGA = 4148;
+        public const int LVM_GETISEARCHSTRINGW = 4213;
+        public const int LVM_GETITEMA = 4101;
+        public const int LVM_GETITEMRECT = 4110;
+        public const int LVM_GETITEMSTATE = 4140;
+        public const int LVM_GETITEMTEXTA = 4141;
+        public const int LVM_GETITEMTEXTW = 4211;
+        public const int LVM_GETITEMW = 4171;
+        public const int LVM_GETNEXTITEM = 4108;
+        public const int LVM_GETSELECTEDCOUNT = 4146;
+        public const int LVM_GETSTRINGWIDTHA = 4113;
+        public const int LVM_GETSTRINGWIDTHW = 4183;
+        public const int LVM_GETSUBITEMRECT = 4152;
+        public const int LVM_GETTILEVIEWINFO = 4259;
+        public const int LVM_GETTOPINDEX = 4135;
+        public const int LVM_HASGROUP = 4257;
+        public const int LVM_HITTEST = 4114;
+        public const int LVM_INSERTCOLUMNA = 4123;
+        public const int LVM_INSERTCOLUMNW = 4193;
+        public const int LVM_INSERTGROUP = 4241;
+        public const int LVM_INSERTITEMA = 4103;
+        public const int LVM_INSERTITEMW = 4173;
+        public const int LVM_INSERTMARKHITTEST = 4264;
+        public const int LVM_ISGROUPVIEWENABLED = 4271;
+        public const int LVM_MOVEITEMTOGROUP = 4250;
+        public const int LVM_REDRAWITEMS = 4117;
+        public const int LVM_REMOVEALLGROUPS = 4256;
+        public const int LVM_REMOVEGROUP = 4246;
+        public const int LVM_SCROLL = 4116;
+        public const int LVM_SETBKCOLOR = 4097;
+        public const int LVM_SETBKIMAGEA = 4164;
+        public const int LVM_SETBKIMAGEW = 4234;
+        public const int LVM_SETCOLUMNA = 4122;
+        public const int LVM_SETCOLUMNW = 4192;
+        public const int LVM_SETCOLUMNWIDTH = 4126;
+        public const int LVM_SETEXTENDEDLISTVIEWSTYLE = 4150;
+        public const int LVM_SETGROUPINFO = 4243;
+        public const int LVM_SETIMAGELIST = 4099;
+        public const int LVM_SETINFOTIP = 4269;
+        public const int LVM_SETINSERTMARK = 4262;
+        public const int LVM_SETINSERTMARKCOLOR = 4266;
+        public const int LVM_SETITEMA = 4102;
+        public const int LVM_SETITEMCOUNT = 4143;
+        public const int LVM_SETITEMPOSITION = 4111;
+        public const int LVM_SETITEMPOSITION32 = 4145;
+        public const int LVM_SETITEMSTATE = 4139;
+        public const int LVM_SETITEMTEXTA = 4142;
+        public const int LVM_SETITEMTEXTW = 4212;
+        public const int LVM_SETITEMW = 4172;
+        public const int LVM_SETTEXTBKCOLOR = 4134;
+        public const int LVM_SETTEXTCOLOR = 4132;
+        public const int LVM_SETTILEVIEWINFO = 4258;
+        public const int LVM_SETTOOLTIPS = 4170;
+        public const int LVM_SETVIEW = 4238;
+        public const int LVM_SORTITEMS = 4144;
+        public const int LVM_SUBITEMHITTEST = 4153;
+        public const int LVM_UPDATE = 4138;
+        public const int LVN_BEGINDRAG = -109;
+        public const int LVN_BEGINLABELEDITA = -105;
+        public const int LVN_BEGINLABELEDITW = -175;
+        public const int LVN_BEGINRDRAG = -111;
+        public const int LVN_COLUMNCLICK = -108;
+        public const int LVN_ENDLABELEDITA = -106;
+        public const int LVN_ENDLABELEDITW = -176;
+        public const int LVN_GETDISPINFOA = -150;
+        public const int LVN_GETDISPINFOW = -177;
+        public const int LVN_GETINFOTIPA = -157;
+        public const int LVN_GETINFOTIPW = -158;
+        public const int LVN_ITEMACTIVATE = -114;
+        public const int LVN_ITEMCHANGED = -101;
+        public const int LVN_ITEMCHANGING = -100;
+        public const int LVN_KEYDOWN = -155;
+        public const int LVN_ODCACHEHINT = -113;
+        public const int LVN_ODFINDITEMA = -152;
+        public const int LVN_ODFINDITEMW = -179;
+        public const int LVN_ODSTATECHANGED = -115;
+        public const int LVN_SETDISPINFOA = -151;
+        public const int LVN_SETDISPINFOW = -178;
+        public const int LVNI_FOCUSED = 1;
+        public const int LVNI_SELECTED = 2;
+        public const int LVS_ALIGNLEFT = 2048;
+        public const int LVS_ALIGNTOP = 0;
+        public const int LVS_AUTOARRANGE = 256;
+        public const int LVS_EDITLABELS = 512;
+        public const int LVS_EX_CHECKBOXES = 4;
+        public const int LVS_EX_FULLROWSELECT = 32;
+        public const int LVS_EX_GRIDLINES = 1;
+        public const int LVS_EX_HEADERDRAGDROP = 16;
+        public const int LVS_EX_INFOTIP = 1024;
+        public const int LVS_EX_ONECLICKACTIVATE = 64;
+        public const int LVS_EX_TRACKSELECT = 8;
+        public const int LVS_EX_TWOCLICKACTIVATE = 128;
+        public const int LVS_EX_UNDERLINEHOT = 2048;
+        public const int LVS_ICON = 0;
+        public const int LVS_LIST = 3;
+        public const int LVS_NOCOLUMNHEADER = 16384;
+        public const int LVS_NOLABELWRAP = 128;
+        public const int LVS_NOSCROLL = 8192;
+        public const int LVS_NOSORTHEADER = 32768;
+        public const int LVS_OWNERDATA = 4096;
+        public const int LVS_REPORT = 1;
+        public const int LVS_SHAREIMAGELISTS = 64;
+        public const int LVS_SHOWSELALWAYS = 8;
+        public const int LVS_SINGLESEL = 4;
+        public const int LVS_SMALLICON = 2;
+        public const int LVS_SORTASCENDING = 16;
+        public const int LVS_SORTDESCENDING = 32;
+        public const int LVSCW_AUTOSIZE = -1;
+        public const int LVSCW_AUTOSIZE_USEHEADER = -2;
+        public const int LVSIL_NORMAL = 0;
+        public const int LVSIL_SMALL = 1;
+        public const int LVSIL_STATE = 2;
+        public const int LVTVIF_FIXEDSIZE = 3;
+        public const int LVTVIM_COLUMNS = 2;
+        public const int LVTVIM_TILESIZE = 1;
+        public const int LWA_ALPHA = 2;
+        public const int LWA_COLORKEY = 1;
+        public const int MAX_PATH = 260;
+        public const int MB_ICONASTERISK = 64;
+        public const int MB_ICONEXCLAMATION = 48;
+        public const int MB_ICONHAND = 16;
+        public const int MB_ICONQUESTION = 32;
+        public const int MB_OK = 0;
+        public const int MCHT_CALENDAR = 131072;
+        public const int MCHT_CALENDARBK = 131072;
+        public const int MCHT_CALENDARDATE = 131073;
+        public const int MCHT_CALENDARDATENEXT = 16908289;
+        public const int MCHT_CALENDARDATEPREV = 33685505;
+        public const int MCHT_CALENDARDAY = 131074;
+        public const int MCHT_CALENDARWEEKNUM = 131075;
+        public const int MCHT_TITLE = 65536;
+        public const int MCHT_TITLEBK = 65536;
+        public const int MCHT_TITLEBTNNEXT = 16842755;
+        public const int MCHT_TITLEBTNPREV = 33619971;
+        public const int MCHT_TITLEMONTH = 65537;
+        public const int MCHT_TITLEYEAR = 65538;
+        public const int MCHT_TODAYLINK = 196608;
+        public const int MCM_GETMAXTODAYWIDTH = 4117;
+        public const int MCM_GETMINREQRECT = 4105;
+        public const int MCM_GETMONTHRANGE = 4103;
+        public const int MCM_GETTODAY = 4109;
+        public const int MCM_HITTEST = 4110;
+        public const int MCM_SETCOLOR = 4106;
+        public const int MCM_SETFIRSTDAYOFWEEK = 4111;
+        public const int MCM_SETMAXSELCOUNT = 4100;
+        public const int MCM_SETMONTHDELTA = 4116;
+        public const int MCM_SETRANGE = 4114;
+        public const int MCM_SETSELRANGE = 4102;
+        public const int MCM_SETTODAY = 4108;
+        public const int MCN_GETDAYSTATE = -747;
+        public const int MCN_SELCHANGE = -749;
+        public const int MCN_SELECT = -746;
+        public const int MCS_DAYSTATE = 1;
+        public const int MCS_MULTISELECT = 2;
+        public const int MCS_NOTODAY = 16;
+        public const int MCS_NOTODAYCIRCLE = 8;
+        public const int MCS_WEEKNUMBERS = 4;
+        public const int MCSC_MONTHBK = 4;
+        public const int MCSC_TEXT = 1;
+        public const int MCSC_TITLEBK = 2;
+        public const int MCSC_TITLETEXT = 3;
+        public const int MCSC_TRAILINGTEXT = 5;
+        public const int MDITILE_HORIZONTAL = 1;
+        public const int MDITILE_VERTICAL = 0;
+        public const int MEMBERID_NIL = -1;
+        public const int MF_BYCOMMAND = 0;
+        public const int MF_BYPOSITION = 1024;
+        public const int MF_ENABLED = 0;
+        public const int MF_GRAYED = 1;
+        public const int MF_POPUP = 16;
+        public const int MF_SYSMENU = 8192;
+        public const int MFT_MENUBREAK = 64;
+        public const int MFT_RIGHTJUSTIFY = 16384;
+        public const int MFT_RIGHTORDER = 8192;
+        public const int MFT_SEPARATOR = 2048;
+        public const int MIIM_DATA = 32;
+        public const int MIIM_ID = 2;
+        public const int MIIM_STATE = 1;
+        public const int MIIM_SUBMENU = 4;
+        public const int MIIM_TYPE = 16;
+        public const int MK_CONTROL = 8;
+        public const int MK_LBUTTON = 1;
+        public const int MK_MBUTTON = 16;
+        public const int MK_RBUTTON = 2;
+        public const int MK_SHIFT = 4;
+        public const int MM_ANISOTROPIC = 8;
+        public const int MM_TEXT = 1;
+        public const int MMIO_ALLOCBUF = 65536;
+        public const int MMIO_FINDRIFF = 32;
+        public const int MMIO_READ = 0;
+        public const int MNC_EXECUTE = 2;
+        public const int MNC_SELECT = 3;
+        public const int MONITOR_OFF = 2;
+        public const int MONITOR_ON = -1;
+        public const int MSAA_MENU_SIG = -1441927155;
+        public const int NFR_ANSI = 1;
+        public const int NFR_UNICODE = 2;
+        public const int NIF_ICON = 2;
+        public const int NIF_INFO = 16;
+        public const int NIF_MESSAGE = 1;
+        public const int NIF_TIP = 4;
+        public const int NIM_ADD = 0;
+        public const int NIM_DELETE = 2;
+        public const int NIM_MODIFY = 1;
+        public const int NIN_BALLOONHIDE = 1027;
+        public const int NIN_BALLOONSHOW = 1026;
+        public const int NIN_BALLOONTIMEOUT = 1028;
+        public const int NIN_BALLOONUSERCLICK = 1029;
+        public const int NM_CLICK = -2;
+        public const int NM_CUSTOMDRAW = -12;
+        public const int NM_DBLCLK = -3;
+        public const int NM_RCLICK = -5;
+        public const int NM_RDBLCLK = -6;
+        public const int NM_RELEASEDCAPTURE = -16;
+        public const int OBJ_BITMAP = 7;
+        public const int OBJ_BRUSH = 2;
+        public const int OBJ_DC = 3;
+        public const int OBJ_ENHMETADC = 12;
+        public const int OBJ_EXTPEN = 11;
+        public const int OBJ_FONT = 6;
+        public const int OBJ_MEMDC = 10;
+        public const int OBJ_METADC = 4;
+        public const int OBJ_METAFILE = 9;
+        public const int OBJ_PAL = 5;
+        public const int OBJ_PEN = 1;
+        public const int OBJ_REGION = 8;
+        public const int ODS_CHECKED = 8;
+        public const int ODS_COMBOBOXEDIT = 4096;
+        public const int ODS_DEFAULT = 32;
+        public const int ODS_DISABLED = 4;
+        public const int ODS_FOCUS = 16;
+        public const int ODS_GRAYED = 2;
+        public const int ODS_HOTLIGHT = 64;
+        public const int ODS_INACTIVE = 128;
+        public const int ODS_NOACCEL = 256;
+        public const int ODS_NOFOCUSRECT = 512;
+        public const int ODS_SELECTED = 1;
+        public const int OFN_ALLOWMULTISELECT = 512;
+        public const int OFN_CREATEPROMPT = 8192;
+        public const int OFN_ENABLEHOOK = 32;
+        public const int OFN_ENABLESIZING = 8388608;
+        public const int OFN_EXPLORER = 524288;
+        public const int OFN_FILEMUSTEXIST = 4096;
+        public const int OFN_HIDEREADONLY = 4;
+        public const int OFN_NOCHANGEDIR = 8;
+        public const int OFN_NODEREFERENCELINKS = 1048576;
+        public const int OFN_NOVALIDATE = 256;
+        public const int OFN_OVERWRITEPROMPT = 2;
+        public const int OFN_PATHMUSTEXIST = 2048;
+        public const int OFN_READONLY = 1;
+        public const int OFN_SHOWHELP = 16;
+        public const int OFN_USESHELLITEM = 16777216;
+        public const int OLE_E_NOCONNECTION = -2147221500;
+        public const int OLE_E_PROMPTSAVECANCELLED = -2147221492;
+        public const int OLECLOSE_PROMPTSAVE = 2;
+        public const int OLECLOSE_SAVEIFDIRTY = 0;
+        public const int OLEIVERB_DISCARDUNDOSTATE = -6;
+        public const int OLEIVERB_HIDE = -3;
+        public const int OLEIVERB_INPLACEACTIVATE = -5;
+        public const int OLEIVERB_PRIMARY = 0;
+        public const int OLEIVERB_PROPERTIES = -7;
+        public const int OLEIVERB_SHOW = -1;
+        public const int OLEIVERB_UIACTIVATE = -4;
+        public const int OLEMISC_ACTIVATEWHENVISIBLE = 256;
+        public const int OLEMISC_ACTSLIKEBUTTON = 4096;
+        public const int OLEMISC_INSIDEOUT = 128;
+        public const int OLEMISC_RECOMPOSEONRESIZE = 1;
+        public const int OLEMISC_SETCLIENTSITEFIRST = 131072;
+        public const int PATCOPY = 15728673;
+        public const int PATINVERT = 5898313;
+        public const int PBM_SETBARCOLOR = 1033;
+        public const int PBM_SETBKCOLOR = 8193;
+        public const int PBM_SETPOS = 1026;
+        public const int PBM_SETRANGE = 1025;
+        public const int PBM_SETRANGE32 = 1030;
+        public const int PBM_SETSTEP = 1028;
+        public const int PBS_SMOOTH = 1;
+        public const int PD_COLLATE = 16;
+        public const int PD_DISABLEPRINTTOFILE = 524288;
+        public const int PD_ENABLEPRINTHOOK = 4096;
+        public const int PD_NOCURRENTPAGE = 8388608;
+        public const int PD_NONETWORKBUTTON = 2097152;
+        public const int PD_NOPAGENUMS = 8;
+        public const int PD_NOSELECTION = 4;
+        public const int PD_PRINTTOFILE = 32;
+        public const int PD_SHOWHELP = 2048;
+        public const int PDERR_CREATEICFAILURE = 4106;
+        public const int PDERR_DEFAULTDIFFERENT = 4108;
+        public const int PDERR_DNDMMISMATCH = 4105;
+        public const int PDERR_GETDEVMODEFAIL = 4101;
+        public const int PDERR_INITFAILURE = 4102;
+        public const int PDERR_LOADDRVFAILURE = 4100;
+        public const int PDERR_NODEFAULTPRN = 4104;
+        public const int PDERR_NODEVICES = 4103;
+        public const int PDERR_PARSEFAILURE = 4098;
+        public const int PDERR_PRINTERNOTFOUND = 4107;
+        public const int PDERR_RETDEFFAILURE = 4099;
+        public const int PDERR_SETUPFAILURE = 4097;
+        public const int PLANES = 14;
+        public const int PM_NOREMOVE = 0;
+        public const int PM_NOYIELD = 2;
+        public const int PM_REMOVE = 1;
+        public const int PRF_CHECKVISIBLE = 1;
+        public const int PRF_CHILDREN = 16;
+        public const int PRF_CLIENT = 4;
+        public const int PRF_ERASEBKGND = 8;
+        public const int PRF_NONCLIENT = 2;
+        public const int PS_DOT = 2;
+        public const int PS_SOLID = 0;
+        public const int PSD_DISABLEMARGINS = 16;
+        public const int PSD_DISABLEORIENTATION = 256;
+        public const int PSD_DISABLEPAPER = 512;
+        public const int PSD_DISABLEPRINTER = 32;
+        public const int PSD_ENABLEPAGESETUPHOOK = 8192;
+        public const int PSD_INHUNDREDTHSOFMILLIMETERS = 8;
+        public const int PSD_MARGINS = 2;
+        public const int PSD_MINMARGINS = 1;
+        public const int PSD_NONETWORKBUTTON = 2097152;
+        public const int PSD_SHOWHELP = 2048;
+        public const int PSM_SETFINISHTEXTA = 1139;
+        public const int PSM_SETFINISHTEXTW = 1145;
+        public const int PSM_SETTITLEA = 1135;
+        public const int PSM_SETTITLEW = 1144;
+        public const int QS_ALLEVENTS = 191;
+        public const int QS_ALLINPUT = 255;
+        public const int QS_ALLPOSTMESSAGE = 256;
+        public const int QS_HOTKEY = 128;
+        public const int QS_INPUT = 7;
+        public const int QS_KEY = 1;
+        public const int QS_MOUSE = 6;
+        public const int QS_MOUSEBUTTON = 4;
+        public const int QS_MOUSEMOVE = 2;
+        public const int QS_PAINT = 32;
+        public const int QS_POSTMESSAGE = 8;
+        public const int QS_SENDMESSAGE = 64;
+        public const int QS_TIMER = 16;
+        public const int RB_INSERTBANDA = 1025;
+        public const int RB_INSERTBANDW = 1034;
+        public const int RDW_ALLCHILDREN = 128;
+        public const int RDW_ERASE = 4;
+        public const int RDW_FRAME = 1024;
+        public const int RDW_INVALIDATE = 1;
+        public const int RGN_AND = 1;
+        public const int RGN_DIFF = 4;
+        public const int RPC_E_CANTCALLOUT_ININPUTSYNCCALL = -2147417843;
+        public const int RPC_E_CHANGED_MODE = -2147417850;
+        public const int S_FALSE = 1;
+        public const int S_OK = 0;
+        public const int SB_BOTTOM = 7;
+        public const int SB_CTL = 2;
+        public const int SB_ENDSCROLL = 8;
+        public const int SB_GETRECT = 1034;
+        public const int SB_GETTEXTA = 1026;
+        public const int SB_GETTEXTLENGTHA = 1027;
+        public const int SB_GETTEXTLENGTHW = 1036;
+        public const int SB_GETTEXTW = 1037;
+        public const int SB_GETTIPTEXTA = 1042;
+        public const int SB_GETTIPTEXTW = 1043;
+        public const int SB_HORZ = 0;
+        public const int SB_LEFT = 6;
+        public const int SB_LINEDOWN = 1;
+        public const int SB_LINELEFT = 0;
+        public const int SB_LINERIGHT = 1;
+        public const int SB_LINEUP = 0;
+        public const int SB_PAGEDOWN = 3;
+        public const int SB_PAGELEFT = 2;
+        public const int SB_PAGERIGHT = 3;
+        public const int SB_PAGEUP = 2;
+        public const int SB_RIGHT = 7;
+        public const int SB_SETICON = 1039;
+        public const int SB_SETPARTS = 1028;
+        public const int SB_SETTEXTA = 1025;
+        public const int SB_SETTEXTW = 1035;
+        public const int SB_SETTIPTEXTA = 1040;
+        public const int SB_SETTIPTEXTW = 1041;
+        public const int SB_SIMPLE = 1033;
+        public const int SB_THUMBPOSITION = 4;
+        public const int SB_THUMBTRACK = 5;
+        public const int SB_TOP = 6;
+        public const int SB_VERT = 1;
+        public const int SBARS_SIZEGRIP = 256;
+        public const int SBS_HORZ = 0;
+        public const int SBS_VERT = 1;
+        public const int SBT_NOBORDERS = 256;
+        public const int SBT_OWNERDRAW = 4096;
+        public const int SBT_POPOUT = 512;
+        public const int SBT_RTLREADING = 1024;
+        public const int SC_CLOSE = 61536;
+        public const int SC_KEYMENU = 61696;
+        public const int SC_MAXIMIZE = 61488;
+        public const int SC_MINIMIZE = 61472;
+        public const int SC_MONITORPOWER = 61808;
+        public const int SC_MOVE = 61456;
+        public const int SC_RESTORE = 61728;
+        public const int SC_SIZE = 61440;
+        public const uint SHACF_AUTOAPPEND_FORCE_OFF = 2147483648u;
+        public const uint SHACF_AUTOAPPEND_FORCE_ON = 1073741824u;
+        public const uint SHACF_AUTOSUGGEST_FORCE_OFF = 536870912u;
+        public const uint SHACF_AUTOSUGGEST_FORCE_ON = 268435456u;
+        public const uint SHACF_DEFAULT = 0u;
+        public const uint SHACF_FILESYS_DIRS = 32u;
+        public const uint SHACF_FILESYS_ONLY = 16u;
+        public const uint SHACF_FILESYSTEM = 1u;
+        public const uint SHACF_URLALL = 6u;
+        public const uint SHACF_URLHISTORY = 2u;
+        public const uint SHACF_URLMRU = 4u;
+        public const uint SHACF_USETAB = 8u;
+        public const int SHGFI_ADDOVERLAYS = 32;
+        public const int SHGFI_ATTR_SPECIFIED = 131072;
+        public const int SHGFI_ATTRIBUTES = 2048;
+        public const int SHGFI_DISPLAYNAME = 512;
+        public const int SHGFI_EXETYPE = 8192;
+        public const int SHGFI_ICON = 256;
+        public const int SHGFI_ICONLOCATION = 4096;
+        public const int SHGFI_LARGEICON = 0;
+        public const int SHGFI_LINKOVERLAY = 32768;
+        public const int SHGFI_OPENICON = 2;
+        public const int SHGFI_OVERLAYINDEX = 64;
+        public const int SHGFI_PIDL = 8;
+        public const int SHGFI_SELECTED = 65536;
+        public const int SHGFI_SHELLICONSIZE = 4;
+        public const int SHGFI_SMALLICON = 1;
+        public const int SHGFI_SYSICONINDEX = 16384;
+        public const int SHGFI_TYPENAME = 1024;
+        public const int SHGFI_USEFILEATTRIBUTES = 16;
+        public const int SHGFP_TYPE_CURRENT = 0;
+        public const int SIF_ALL = 23;
+        public const int SIF_PAGE = 2;
+        public const int SIF_POS = 4;
+        public const int SIF_RANGE = 1;
+        public const int SIF_TRACKPOS = 16;
+        public const int SM_ARRANGE = 56;
+        public const int SM_CLEANBOOT = 67;
+        public const int SM_CMONITORS = 80;
+        public const int SM_CMOUSEBUTTONS = 43;
+        public const int SM_CXBORDER = 5;
+        public const int SM_CXCURSOR = 13;
+        public const int SM_CXDOUBLECLK = 36;
+        public const int SM_CXDRAG = 68;
+        public const int SM_CXEDGE = 45;
+        public const int SM_CXFIXEDFRAME = 7;
+        public const int SM_CXFOCUSBORDER = 83;
+        public const int SM_CXFRAME = 32;
+        public const int SM_CXHSCROLL = 21;
+        public const int SM_CXHTHUMB = 10;
+        public const int SM_CXICON = 11;
+        public const int SM_CXICONSPACING = 38;
+        public const int SM_CXMAXIMIZED = 61;
+        public const int SM_CXMAXTRACK = 59;
+        public const int SM_CXMENUCHECK = 71;
+        public const int SM_CXMENUSIZE = 54;
+        public const int SM_CXMIN = 28;
+        public const int SM_CXMINIMIZED = 57;
+        public const int SM_CXMINSPACING = 47;
+        public const int SM_CXMINTRACK = 34;
+        public const int SM_CXSCREEN = 0;
+        public const int SM_CXSIZE = 30;
+        public const int SM_CXSIZEFRAME = 32;
+        public const int SM_CXSMICON = 49;
+        public const int SM_CXSMSIZE = 52;
+        public const int SM_CXVIRTUALSCREEN = 78;
+        public const int SM_CXVSCROLL = 2;
+        public const int SM_CYBORDER = 6;
+        public const int SM_CYCAPTION = 4;
+        public const int SM_CYCURSOR = 14;
+        public const int SM_CYDOUBLECLK = 37;
+        public const int SM_CYDRAG = 69;
+        public const int SM_CYEDGE = 46;
+        public const int SM_CYFIXEDFRAME = 8;
+        public const int SM_CYFOCUSBORDER = 84;
+        public const int SM_CYFRAME = 33;
+        public const int SM_CYHSCROLL = 3;
+        public const int SM_CYICON = 12;
+        public const int SM_CYICONSPACING = 39;
+        public const int SM_CYKANJIWINDOW = 18;
+        public const int SM_CYMAXIMIZED = 62;
+        public const int SM_CYMAXTRACK = 60;
+        public const int SM_CYMENU = 15;
+        public const int SM_CYMENUCHECK = 72;
+        public const int SM_CYMENUSIZE = 55;
+        public const int SM_CYMIN = 29;
+        public const int SM_CYMINIMIZED = 58;
+        public const int SM_CYMINSPACING = 48;
+        public const int SM_CYMINTRACK = 35;
+        public const int SM_CYSCREEN = 1;
+        public const int SM_CYSIZE = 31;
+        public const int SM_CYSIZEFRAME = 33;
+        public const int SM_CYSMCAPTION = 51;
+        public const int SM_CYSMICON = 50;
+        public const int SM_CYSMSIZE = 53;
+        public const int SM_CYVIRTUALSCREEN = 79;
+        public const int SM_CYVSCROLL = 20;
+        public const int SM_CYVTHUMB = 9;
+        public const int SM_DBCSENABLED = 42;
+        public const int SM_DEBUG = 22;
+        public const int SM_MENUDROPALIGNMENT = 40;
+        public const int SM_MIDEASTENABLED = 74;
+        public const int SM_MOUSEPRESENT = 19;
+        public const int SM_MOUSEWHEELPRESENT = 75;
+        public const int SM_NETWORK = 63;
+        public const int SM_PENWINDOWS = 41;
+        public const int SM_REMOTESESSION = 4096;
+        public const int SM_SAMEDISPLAYFORMAT = 81;
+        public const int SM_SECURE = 44;
+        public const int SM_SHOWSOUNDS = 70;
+        public const int SM_SWAPBUTTON = 23;
+        public const int SM_XVIRTUALSCREEN = 76;
+        public const int SM_YVIRTUALSCREEN = 77;
+        public const int SND_ASYNC = 1;
+        public const int SND_FILENAME = 131072;
+        public const int SND_LOOP = 8;
+        public const int SND_MEMORY = 4;
+        public const int SND_NODEFAULT = 2;
+        public const int SND_NOSTOP = 16;
+        public const int SND_PURGE = 64;
+        public const int SND_SYNC = 0;
+        public const int SORT_DEFAULT = 0;
+        public const int SPI_GETACTIVEWINDOWTRACKING = 4096;
+        public const int SPI_GETACTIVEWNDTRKTIMEOUT = 8194;
+        public const int SPI_GETANIMATION = 72;
+        public const int SPI_GETBORDER = 5;
+        public const int SPI_GETCARETWIDTH = 8198;
+        public const int SPI_GETCOMBOBOXANIMATION = 4100;
+        public const int SPI_GETDEFAULTINPUTLANG = 89;
+        public const int SPI_GETDRAGFULLWINDOWS = 38;
+        public const int SPI_GETDROPSHADOW = 4132;
+        public const int SPI_GETFLATMENU = 4130;
+        public const int SPI_GETFONTSMOOTHING = 74;
+        public const int SPI_GETFONTSMOOTHINGCONTRAST = 8204;
+        public const int SPI_GETFONTSMOOTHINGTYPE = 8202;
+        public const int SPI_GETGRADIENTCAPTIONS = 4104;
+        public const int SPI_GETHIGHCONTRAST = 66;
+        public const int SPI_GETHOTTRACKING = 4110;
+        public const int SPI_GETICONTITLELOGFONT = 31;
+        public const int SPI_GETICONTITLEWRAP = 25;
+        public const int SPI_GETKEYBOARDCUES = 4106;
+        public const int SPI_GETKEYBOARDDELAY = 22;
+        public const int SPI_GETKEYBOARDPREF = 68;
+        public const int SPI_GETKEYBOARDSPEED = 10;
+        public const int SPI_GETLISTBOXSMOOTHSCROLLING = 4102;
+        public const int SPI_GETMENUANIMATION = 4098;
+        public const int SPI_GETMENUDROPALIGNMENT = 27;
+        public const int SPI_GETMENUFADE = 4114;
+        public const int SPI_GETMENUSHOWDELAY = 106;
+        public const int SPI_GETMOUSEHOVERHEIGHT = 100;
+        public const int SPI_GETMOUSEHOVERTIME = 102;
+        public const int SPI_GETMOUSEHOVERWIDTH = 98;
+        public const int SPI_GETMOUSESPEED = 112;
+        public const int SPI_GETNONCLIENTMETRICS = 41;
+        public const int SPI_GETSELECTIONFADE = 4116;
+        public const int SPI_GETSNAPTODEFBUTTON = 95;
+        public const int SPI_GETTOOLTIPANIMATION = 4118;
+        public const int SPI_GETUIEFFECTS = 4158;
+        public const int SPI_GETWHEELSCROLLLINES = 104;
+        public const int SPI_GETWORKAREA = 48;
+        public const int SPI_ICONHORIZONTALSPACING = 13;
+        public const int SPI_ICONVERTICALSPACING = 24;
+        public const int SRCCOPY = 13369376;
+        public const int SS_CENTER = 1;
+        public const int SS_LEFT = 0;
+        public const int SS_NOPREFIX = 128;
+        public const int SS_OWNERDRAW = 13;
+        public const int SS_RIGHT = 2;
+        public const int SS_SUNKEN = 4096;
+        public const int STARTF_USESHOWWINDOW = 1;
+        public const int STATFLAG_DEFAULT = 0;
+        public const int STATFLAG_NONAME = 1;
+        public const int STATFLAG_NOOPEN = 2;
+        public const int stc4 = 1091;
+        public const int STG_E_ACCESSDENIED = -2147287035;
+        public const int STG_E_DISKISWRITEPROTECTED = -2147287021;
+        public const int STG_E_FILENOTFOUND = -2147287038;
+        public const int STG_E_INSUFFICIENTMEMORY = -2147287032;
+        public const int STG_E_INVALIDFUNCTION = -2147287039;
+        public const int STG_E_INVALIDHANDLE = -2147287034;
+        public const int STG_E_INVALIDPOINTER = -2147287031;
+        public const int STG_E_LOCKVIOLATION = -2147287007;
+        public const int STG_E_NOMOREFILES = -2147287022;
+        public const int STG_E_PATHNOTFOUND = -2147287037;
+        public const int STG_E_READFAULT = -2147287010;
+        public const int STG_E_SEEKERROR = -2147287015;
+        public const int STG_E_SHAREVIOLATION = -2147287008;
+        public const int STG_E_TOOMANYOPENFILES = -2147287036;
+        public const int STG_E_WRITEFAULT = -2147287011;
+        public const int STGC_DANGEROUSLYCOMMITMERELYTODISKCACHE = 4;
+        public const int STGC_DEFAULT = 0;
+        public const int STGC_ONLYIFCURRENT = 2;
+        public const int STGC_OVERWRITE = 1;
+        public const int STGM_CONVERT = 131072;
+        public const int STGM_CREATE = 4096;
+        public const int STGM_DELETEONRELEASE = 67108864;
+        public const int STGM_READ = 0;
+        public const int STGM_READWRITE = 2;
+        public const int STGM_SHARE_EXCLUSIVE = 16;
+        public const int STGM_TRANSACTED = 65536;
+        public const int STGM_WRITE = 1;
+        public const int STREAM_SEEK_CUR = 1;
+        public const int STREAM_SEEK_END = 2;
+        public const int STREAM_SEEK_SET = 0;
+        public const int SUBLANG_DEFAULT = 1;
+        public const int SW_ERASE = 4;
+        public const int SW_HIDE = 0;
+        public const int SW_INVALIDATE = 2;
+        public const int SW_MAX = 10;
+        public const int SW_MAXIMIZE = 3;
+        public const int SW_MINIMIZE = 6;
+        public const int SW_NORMAL = 1;
+        public const int SW_RESTORE = 9;
+        public const int SW_SCROLLCHILDREN = 1;
+        public const int SW_SHOW = 5;
+        public const int SW_SHOWMAXIMIZED = 3;
+        public const int SW_SHOWMINIMIZED = 2;
+        public const int SW_SHOWMINNOACTIVE = 7;
+        public const int SW_SHOWNA = 8;
+        public const int SW_SHOWNOACTIVATE = 4;
+        public const int SW_SMOOTHSCROLL = 16;
+        public const int SWP_DRAWFRAME = 32;
+        public const int SWP_HIDEWINDOW = 128;
+        public const int SWP_NOACTIVATE = 16;
+        public const int SWP_NOMOVE = 2;
+        public const int SWP_NOSIZE = 1;
+        public const int SWP_NOZORDER = 4;
+        public const int SWP_SHOWWINDOW = 64;
+        public const int TB_ADDBUTTONSA = 1044;
+        public const int TB_ADDBUTTONSW = 1092;
+        public const int TB_ADDSTRINGA = 1052;
+        public const int TB_ADDSTRINGW = 1101;
+        public const int TB_AUTOSIZE = 1057;
+        public const int TB_BOTTOM = 7;
+        public const int TB_BUTTONSTRUCTSIZE = 1054;
+        public const int TB_DELETEBUTTON = 1046;
+        public const int TB_ENABLEBUTTON = 1025;
+        public const int TB_ENDTRACK = 8;
+        public const int TB_GETBUTTON = 1047;
+        public const int TB_GETBUTTONINFOA = 1089;
+        public const int TB_GETBUTTONINFOW = 1087;
+        public const int TB_GETBUTTONSIZE = 1082;
+        public const int TB_GETBUTTONTEXTA = 1069;
+        public const int TB_GETBUTTONTEXTW = 1099;
+        public const int TB_GETRECT = 1075;
+        public const int TB_GETROWS = 1064;
+        public const int TB_INSERTBUTTONA = 1045;
+        public const int TB_INSERTBUTTONW = 1091;
+        public const int TB_ISBUTTONCHECKED = 1034;
+        public const int TB_ISBUTTONINDETERMINATE = 1037;
+        public const int TB_LINEDOWN = 1;
+        public const int TB_LINEUP = 0;
+        public const int TB_MAPACCELERATORA = 1102;
+        public const int TB_MAPACCELERATORW = 1114;
+        public const int TB_PAGEDOWN = 3;
+        public const int TB_PAGEUP = 2;
+        public const int TB_SAVERESTOREA = 1050;
+        public const int TB_SAVERESTOREW = 1100;
+        public const int TB_SETBUTTONINFOA = 1090;
+        public const int TB_SETBUTTONINFOW = 1088;
+        public const int TB_SETBUTTONSIZE = 1055;
+        public const int TB_SETEXTENDEDSTYLE = 1108;
+        public const int TB_SETIMAGELIST = 1072;
+        public const int TB_SETTOOLTIPS = 1060;
+        public const int TB_THUMBPOSITION = 4;
+        public const int TB_THUMBTRACK = 5;
+        public const int TB_TOP = 6;
+        public const int TBIF_COMMAND = 32;
+        public const int TBIF_IMAGE = 1;
+        public const int TBIF_SIZE = 64;
+        public const int TBIF_STATE = 4;
+        public const int TBIF_STYLE = 8;
+        public const int TBIF_TEXT = 2;
+        public const int TBM_GETPOS = 1024;
+        public const int TBM_SETLINESIZE = 1047;
+        public const int TBM_SETPAGESIZE = 1045;
+        public const int TBM_SETPOS = 1029;
+        public const int TBM_SETRANGE = 1030;
+        public const int TBM_SETRANGEMAX = 1032;
+        public const int TBM_SETRANGEMIN = 1031;
+        public const int TBM_SETTIC = 1028;
+        public const int TBM_SETTICFREQ = 1044;
+        public const int TBN_DROPDOWN = -710;
+        public const int TBN_GETBUTTONINFOA = -700;
+        public const int TBN_GETBUTTONINFOW = -720;
+        public const int TBN_GETDISPINFOA = -716;
+        public const int TBN_GETDISPINFOW = -717;
+        public const int TBN_GETINFOTIPA = -718;
+        public const int TBN_GETINFOTIPW = -719;
+        public const int TBN_QUERYINSERT = -706;
+        public const int TBS_AUTOTICKS = 1;
+        public const int TBS_BOTH = 8;
+        public const int TBS_BOTTOM = 0;
+        public const int TBS_NOTICKS = 16;
+        public const int TBS_TOP = 4;
+        public const int TBS_VERT = 2;
+        public const int TBSTATE_CHECKED = 1;
+        public const int TBSTATE_ENABLED = 4;
+        public const int TBSTATE_HIDDEN = 8;
+        public const int TBSTATE_INDETERMINATE = 16;
+        public const int TBSTYLE_BUTTON = 0;
+        public const int TBSTYLE_CHECK = 2;
+        public const int TBSTYLE_DROPDOWN = 8;
+        public const int TBSTYLE_EX_DRAWDDARROWS = 1;
+        public const int TBSTYLE_FLAT = 2048;
+        public const int TBSTYLE_LIST = 4096;
+        public const int TBSTYLE_SEP = 1;
+        public const int TBSTYLE_TOOLTIPS = 256;
+        public const int TBSTYLE_WRAPPABLE = 512;
+        public const int TCIF_IMAGE = 2;
+        public const int TCIF_TEXT = 1;
+        public const int TCM_ADJUSTRECT = 4904;
+        public const int TCM_DELETEALLITEMS = 4873;
+        public const int TCM_DELETEITEM = 4872;
+        public const int TCM_GETCURSEL = 4875;
+        public const int TCM_GETITEMA = 4869;
+        public const int TCM_GETITEMRECT = 4874;
+        public const int TCM_GETITEMW = 4924;
+        public const int TCM_GETROWCOUNT = 4908;
+        public const int TCM_GETTOOLTIPS = 4909;
+        public const int TCM_INSERTITEMA = 4871;
+        public const int TCM_INSERTITEMW = 4926;
+        public const int TCM_SETCURSEL = 4876;
+        public const int TCM_SETIMAGELIST = 4867;
+        public const int TCM_SETITEMA = 4870;
+        public const int TCM_SETITEMSIZE = 4905;
+        public const int TCM_SETITEMW = 4925;
+        public const int TCM_SETPADDING = 4907;
+        public const int TCM_SETTOOLTIPS = 4910;
+        public const int TCN_SELCHANGE = -551;
+        public const int TCN_SELCHANGING = -552;
+        public const int TCS_BOTTOM = 2;
+        public const int TCS_BUTTONS = 256;
+        public const int TCS_FIXEDWIDTH = 1024;
+        public const int TCS_FLATBUTTONS = 8;
+        public const int TCS_HOTTRACK = 64;
+        public const int TCS_MULTILINE = 512;
+        public const int TCS_OWNERDRAWFIXED = 8192;
+        public const int TCS_RAGGEDRIGHT = 2048;
+        public const int TCS_RIGHT = 2;
+        public const int TCS_RIGHTJUSTIFY = 0;
+        public const int TCS_TABS = 0;
+        public const int TCS_TOOLTIPS = 16384;
+        public const int TCS_VERTICAL = 128;
+        public const int TME_HOVER = 1;
+        public const int TME_LEAVE = 2;
+        public const int TPM_LEFTALIGN = 0;
+        public const int TPM_LEFTBUTTON = 0;
+        public const int TPM_VERTICAL = 64;
+        public const int TRANSPARENT = 1;
+        public const int TTDT_AUTOMATIC = 0;
+        public const int TTDT_AUTOPOP = 2;
+        public const int TTDT_INITIAL = 3;
+        public const int TTDT_RESHOW = 1;
+        public const int TTF_ABSOLUTE = 128;
+        public const int TTF_CENTERTIP = 2;
+        public const int TTF_IDISHWND = 1;
+        public const int TTF_RTLREADING = 4;
+        public const int TTF_SUBCLASS = 16;
+        public const int TTF_TRACK = 32;
+        public const int TTF_TRANSPARENT = 256;
+        public const int TTI_WARNING = 2;
+        public const int TTM_ACTIVATE = 1025;
+        public const int TTM_ADDTOOLA = 1028;
+        public const int TTM_ADDTOOLW = 1074;
+        public const int TTM_ADJUSTRECT = 1055;
+        public const int TTM_DELTOOLA = 1029;
+        public const int TTM_DELTOOLW = 1075;
+        public const int TTM_ENUMTOOLSA = 1038;
+        public const int TTM_ENUMTOOLSW = 1082;
+        public const int TTM_GETCURRENTTOOLA = 1039;
+        public const int TTM_GETCURRENTTOOLW = 1083;
+        public const int TTM_GETDELAYTIME = 1045;
+        public const int TTM_GETTEXTA = 1035;
+        public const int TTM_GETTEXTW = 1080;
+        public const int TTM_GETTIPBKCOLOR = 1046;
+        public const int TTM_GETTIPTEXTCOLOR = 1047;
+        public const int TTM_GETTOOLINFOA = 1032;
+        public const int TTM_GETTOOLINFOW = 1077;
+        public const int TTM_HITTESTA = 1034;
+        public const int TTM_HITTESTW = 1079;
+        public const int TTM_NEWTOOLRECTA = 1030;
+        public const int TTM_NEWTOOLRECTW = 1076;
+        public const int TTM_POP = 1052;
+        public const int TTM_RELAYEVENT = 1031;
+        public const int TTM_SETDELAYTIME = 1027;
+        public const int TTM_SETMAXTIPWIDTH = 1048;
+        public const int TTM_SETTIPBKCOLOR = 1043;
+        public const int TTM_SETTIPTEXTCOLOR = 1044;
+        public const int TTM_SETTITLEA = 1056;
+        public const int TTM_SETTITLEW = 1057;
+        public const int TTM_SETTOOLINFOA = 1033;
+        public const int TTM_SETTOOLINFOW = 1078;
+        public const int TTM_TRACKACTIVATE = 1041;
+        public const int TTM_TRACKPOSITION = 1042;
+        public const int TTM_UPDATE = 1053;
+        public const int TTM_UPDATETIPTEXTA = 1036;
+        public const int TTM_UPDATETIPTEXTW = 1081;
+        public const int TTM_WINDOWFROMPOINT = 1040;
+        public const int TTN_GETDISPINFOA = -520;
+        public const int TTN_GETDISPINFOW = -530;
+        public const int TTN_NEEDTEXTA = -520;
+        public const int TTN_NEEDTEXTW = -530;
+        public const int TTN_POP = -522;
+        public const int TTN_SHOW = -521;
+        public const int TTS_ALWAYSTIP = 1;
+        public const int TTS_BALLOON = 64;
+        public const int TTS_NOANIMATE = 16;
+        public const int TTS_NOFADE = 32;
+        public const int TTS_NOPREFIX = 2;
+        public const int TV_FIRST = 4352;
+        public const int TVC_BYKEYBOARD = 2;
+        public const int TVC_BYMOUSE = 1;
+        public const int TVC_UNKNOWN = 0;
+        public const int TVE_COLLAPSE = 1;
+        public const int TVE_EXPAND = 2;
+        public const int TVGN_CARET = 9;
+        public const int TVGN_FIRSTVISIBLE = 5;
+        public const int TVGN_NEXT = 1;
+        public const int TVGN_NEXTVISIBLE = 6;
+        public const int TVGN_PREVIOUS = 2;
+        public const int TVGN_PREVIOUSVISIBLE = 7;
+        public const int TVHT_ABOVE = 256;
+        public const int TVHT_BELOW = 512;
+        public const int TVHT_NOWHERE = 1;
+        public const int TVHT_ONITEM = 70;
+        public const int TVHT_ONITEMBUTTON = 16;
+        public const int TVHT_ONITEMICON = 2;
+        public const int TVHT_ONITEMINDENT = 8;
+        public const int TVHT_ONITEMLABEL = 4;
+        public const int TVHT_ONITEMRIGHT = 32;
+        public const int TVHT_ONITEMSTATEICON = 64;
+        public const int TVHT_TOLEFT = 2048;
+        public const int TVHT_TORIGHT = 1024;
+        public const int TVI_FIRST = -65535;
+        public const int TVI_ROOT = -65536;
+        public const int TVIF_HANDLE = 16;
+        public const int TVIF_IMAGE = 2;
+        public const int TVIF_PARAM = 4;
+        public const int TVIF_SELECTEDIMAGE = 32;
+        public const int TVIF_STATE = 8;
+        public const int TVIF_TEXT = 1;
+        public const int TVIS_EXPANDED = 32;
+        public const int TVIS_EXPANDEDONCE = 64;
+        public const int TVIS_SELECTED = 2;
+        public const int TVIS_STATEIMAGEMASK = 61440;
+        public const int TVM_DELETEITEM = 4353;
+        public const int TVM_EDITLABELA = 4366;
+        public const int TVM_EDITLABELW = 4417;
+        public const int TVM_ENDEDITLABELNOW = 4374;
+        public const int TVM_ENSUREVISIBLE = 4372;
+        public const int TVM_EXPAND = 4354;
+        public const int TVM_GETEDITCONTROL = 4367;
+        public const int TVM_GETINDENT = 4358;
+        public const int TVM_GETISEARCHSTRINGA = 4375;
+        public const int TVM_GETISEARCHSTRINGW = 4416;
+        public const int TVM_GETITEMA = 4364;
+        public const int TVM_GETITEMHEIGHT = 4380;
+        public const int TVM_GETITEMRECT = 4356;
+        public const int TVM_GETITEMW = 4414;
+        public const int TVM_GETLINECOLOR = 4393;
+        public const int TVM_GETNEXTITEM = 4362;
+        public const int TVM_GETVISIBLECOUNT = 4368;
+        public const int TVM_HITTEST = 4369;
+        public const int TVM_INSERTITEMA = 4352;
+        public const int TVM_INSERTITEMW = 4402;
+        public const int TVM_SELECTITEM = 4363;
+        public const int TVM_SETBKCOLOR = 4381;
+        public const int TVM_SETIMAGELIST = 4361;
+        public const int TVM_SETINDENT = 4359;
+        public const int TVM_SETITEMA = 4365;
+        public const int TVM_SETITEMHEIGHT = 4379;
+        public const int TVM_SETITEMW = 4415;
+        public const int TVM_SETLINECOLOR = 4392;
+        public const int TVM_SETTEXTCOLOR = 4382;
+        public const int TVM_SETTOOLTIPS = 4376;
+        public const int TVM_SORTCHILDRENCB = 4373;
+        public const int TVN_BEGINDRAGA = -407;
+        public const int TVN_BEGINDRAGW = -456;
+        public const int TVN_BEGINLABELEDITA = -410;
+        public const int TVN_BEGINLABELEDITW = -459;
+        public const int TVN_BEGINRDRAGA = -408;
+        public const int TVN_BEGINRDRAGW = -457;
+        public const int TVN_ENDLABELEDITA = -411;
+        public const int TVN_ENDLABELEDITW = -460;
+        public const int TVN_GETDISPINFOA = -403;
+        public const int TVN_GETDISPINFOW = -452;
+        public const int TVN_GETINFOTIPA = -413;
+        public const int TVN_GETINFOTIPW = -414;
+        public const int TVN_ITEMEXPANDEDA = -406;
+        public const int TVN_ITEMEXPANDEDW = -455;
+        public const int TVN_ITEMEXPANDINGA = -405;
+        public const int TVN_ITEMEXPANDINGW = -454;
+        public const int TVN_SELCHANGEDA = -402;
+        public const int TVN_SELCHANGEDW = -451;
+        public const int TVN_SELCHANGINGA = -401;
+        public const int TVN_SELCHANGINGW = -450;
+        public const int TVN_SETDISPINFOA = -404;
+        public const int TVN_SETDISPINFOW = -453;
+        public const int TVS_CHECKBOXES = 256;
+        public const int TVS_EDITLABELS = 8;
+        public const int TVS_FULLROWSELECT = 4096;
+        public const int TVS_HASBUTTONS = 1;
+        public const int TVS_HASLINES = 2;
+        public const int TVS_INFOTIP = 2048;
+        public const int TVS_LINESATROOT = 4;
+        public const int TVS_NOTOOLTIPS = 128;
+        public const int TVS_RTLREADING = 64;
+        public const int TVS_SHOWSELALWAYS = 32;
+        public const int TVS_TRACKSELECT = 512;
+        public const int TVSIL_STATE = 2;
+        public const int TYMED_NULL = 0;
+        public const int UIS_CLEAR = 2;
+        public const int UIS_INITIALIZE = 3;
+        public const int UIS_SET = 1;
+        public const int UISF_HIDEACCEL = 2;
+        public const int UISF_HIDEFOCUS = 1;
+        public const int UOI_FLAGS = 1;
+        public const int USERCLASSTYPE_APPNAME = 3;
+        public const int USERCLASSTYPE_FULL = 1;
+        public const int USERCLASSTYPE_SHORT = 2;
+        public const int VIEW_E_DRAW = -2147221184;
+        public const int VK_CAPSLOCK = 20;
+        public const int VK_CONTROL = 17;
+        public const int VK_DOWN = 40;
+        public const int VK_ESCAPE = 27;
+        public const int VK_LEFT = 37;
+        public const int VK_MENU = 18;
+        public const int VK_NUMLOCK = 144;
+        public const int VK_RIGHT = 39;
+        public const int VK_SCROLL = 145;
+        public const int VK_SHIFT = 16;
+        public const int VK_TAB = 9;
+        public const int VK_UP = 38;
+        public const int WA_ACTIVE = 1;
+        public const int WA_CLICKACTIVE = 2;
+        public const int WA_INACTIVE = 0;
+        public const int WAVE_FORMAT_ADPCM = 2;
+        public const int WAVE_FORMAT_IEEE_FLOAT = 3;
+        public const int WAVE_FORMAT_PCM = 1;
+        public const int WH_GETMESSAGE = 3;
+        public const int WH_JOURNALPLAYBACK = 1;
+        public const int WH_KEYBOARD_LL = 13;
+        public const int WH_MOUSE = 7;
+        public const int WHEEL_DELTA = 120;
+        public const int WM_ACTIVATE = 6;
+        public const int WM_ACTIVATEAPP = 28;
+        public const int WM_AFXFIRST = 864;
+        public const int WM_AFXLAST = 895;
+        public const int WM_APP = 32768;
+        public const int WM_ASKCBFORMATNAME = 780;
+        public const int WM_CANCELJOURNAL = 75;
+        public const int WM_CANCELMODE = 31;
+        public const int WM_CAPTURECHANGED = 533;
+        public const int WM_CHANGECBCHAIN = 781;
+        public const int WM_CHANGEUISTATE = 295;
+        public const int WM_CHAR = 258;
+        public const int WM_CHARTOITEM = 47;
+        public const int WM_CHILDACTIVATE = 34;
+        public const int WM_CHOOSEFONT_GETLOGFONT = 1025;
+        public const int WM_CLEAR = 771;
+        public const int WM_CLOSE = 16;
+        public const int WM_COMMAND = 273;
+        public const int WM_COMMNOTIFY = 68;
+        public const int WM_COMPACTING = 65;
+        public const int WM_COMPAREITEM = 57;
+        public const int WM_CONTEXTMENU = 123;
+        public const int WM_COPY = 769;
+        public const int WM_COPYDATA = 74;
+        public const int WM_CREATE = 1;
+        public const int WM_CTLCOLOR = 25;
+        public const int WM_CTLCOLORBTN = 309;
+        public const int WM_CTLCOLORDLG = 310;
+        public const int WM_CTLCOLOREDIT = 307;
+        public const int WM_CTLCOLORLISTBOX = 308;
+        public const int WM_CTLCOLORMSGBOX = 306;
+        public const int WM_CTLCOLORSCROLLBAR = 311;
+        public const int WM_CTLCOLORSTATIC = 312;
+        public const int WM_CUT = 768;
+        public const int WM_DEADCHAR = 259;
+        public const int WM_DELETEITEM = 45;
+        public const int WM_DESTROY = 2;
+        public const int WM_DESTROYCLIPBOARD = 775;
+        public const int WM_DEVICECHANGE = 537;
+        public const int WM_DEVMODECHANGE = 27;
+        public const int WM_DISPLAYCHANGE = 126;
+        public const int WM_DRAWCLIPBOARD = 776;
+        public const int WM_DRAWITEM = 43;
+        public const int WM_DROPFILES = 563;
+        public const int WM_ENABLE = 10;
+        public const int WM_ENDSESSION = 22;
+        public const int WM_ENTERIDLE = 289;
+        public const int WM_ENTERMENULOOP = 529;
+        public const int WM_ENTERSIZEMOVE = 561;
+        public const int WM_ERASEBKGND = 20;
+        public const int WM_EXITMENULOOP = 530;
+        public const int WM_EXITSIZEMOVE = 562;
+        public const int WM_FONTCHANGE = 29;
+        public const int WM_GETDLGCODE = 135;
+        public const int WM_GETFONT = 49;
+        public const int WM_GETHOTKEY = 51;
+        public const int WM_GETICON = 127;
+        public const int WM_GETMINMAXINFO = 36;
+        public const int WM_GETOBJECT = 61;
+        public const int WM_GETTEXT = 13;
+        public const int WM_GETTEXTLENGTH = 14;
+        public const int WM_HANDHELDFIRST = 856;
+        public const int WM_HANDHELDLAST = 863;
+        public const int WM_HELP = 83;
+        public const int WM_HOTKEY = 786;
+        public const int WM_HSCROLL = 276;
+        public const int WM_HSCROLLCLIPBOARD = 782;
+        public const int WM_ICONERASEBKGND = 39;
+        public const int WM_IME_CHAR = 646;
+        public const int WM_IME_COMPOSITION = 271;
+        public const int WM_IME_COMPOSITIONFULL = 644;
+        public const int WM_IME_CONTROL = 643;
+        public const int WM_IME_ENDCOMPOSITION = 270;
+        public const int WM_IME_KEYDOWN = 656;
+        public const int WM_IME_KEYLAST = 271;
+        public const int WM_IME_KEYUP = 657;
+        public const int WM_IME_NOTIFY = 642;
+        public const int WM_IME_SELECT = 645;
+        public const int WM_IME_SETCONTEXT = 641;
+        public const int WM_IME_STARTCOMPOSITION = 269;
+        public const int WM_INITDIALOG = 272;
+        public const int WM_INITMENU = 278;
+        public const int WM_INITMENUPOPUP = 279;
+        public const int WM_INPUTLANGCHANGE = 81;
+        public const int WM_INPUTLANGCHANGEREQUEST = 80;
+        public const int WM_KEYDOWN = 256;
+        public const int WM_KEYFIRST = 256;
+        public const int WM_KEYLAST = 264;
+        public const int WM_KEYUP = 257;
+        public const int WM_KILLFOCUS = 8;
+        public const int WM_LBUTTONDBLCLK = 515;
+        public const int WM_LBUTTONDOWN = 513;
+        public const int WM_LBUTTONUP = 514;
+        public const int WM_MBUTTONDBLCLK = 521;
+        public const int WM_MBUTTONDOWN = 519;
+        public const int WM_MBUTTONUP = 520;
+        public const int WM_MDIACTIVATE = 546;
+        public const int WM_MDICASCADE = 551;
+        public const int WM_MDICREATE = 544;
+        public const int WM_MDIDESTROY = 545;
+        public const int WM_MDIGETACTIVE = 553;
+        public const int WM_MDIICONARRANGE = 552;
+        public const int WM_MDIMAXIMIZE = 549;
+        public const int WM_MDINEXT = 548;
+        public const int WM_MDIREFRESHMENU = 564;
+        public const int WM_MDIRESTORE = 547;
+        public const int WM_MDISETMENU = 560;
+        public const int WM_MDITILE = 550;
+        public const int WM_MEASUREITEM = 44;
+        public const int WM_MENUCHAR = 288;
+        public const int WM_MENUSELECT = 287;
+        public const int WM_MOUSEACTIVATE = 33;
+        public const int WM_MOUSEFIRST = 512;
+        public const int WM_MOUSEHOVER = 673;
+        public const int WM_MOUSELAST = 522;
+        public const int WM_MOUSELEAVE = 675;
+        public const int WM_MOUSEMOVE = 512;
+        public const int WM_MOUSEWHEEL = 522;
+        public const int WM_MOVE = 3;
+        public const int WM_MOVING = 534;
+        public const int WM_NCACTIVATE = 134;
+        public const int WM_NCCALCSIZE = 131;
+        public const int WM_NCCREATE = 129;
+        public const int WM_NCDESTROY = 130;
+        public const int WM_NCHITTEST = 132;
+        public const int WM_NCLBUTTONDBLCLK = 163;
+        public const int WM_NCLBUTTONDOWN = 161;
+        public const int WM_NCLBUTTONUP = 162;
+        public const int WM_NCMBUTTONDBLCLK = 169;
+        public const int WM_NCMBUTTONDOWN = 167;
+        public const int WM_NCMBUTTONUP = 168;
+        public const int WM_NCMOUSEMOVE = 160;
+        public const int WM_NCPAINT = 133;
+        public const int WM_NCRBUTTONDBLCLK = 166;
+        public const int WM_NCRBUTTONDOWN = 164;
+        public const int WM_NCRBUTTONUP = 165;
+        public const int WM_NCXBUTTONDBLCLK = 173;
+        public const int WM_NCXBUTTONDOWN = 171;
+        public const int WM_NCXBUTTONUP = 172;
+        public const int WM_NEXTDLGCTL = 40;
+        public const int WM_NEXTMENU = 531;
+        public const int WM_NOTIFY = 78;
+        public const int WM_NOTIFYFORMAT = 85;
+        public const int WM_NULL = 0;
+        public const int WM_PAINT = 15;
+        public const int WM_PAINTCLIPBOARD = 777;
+        public const int WM_PAINTICON = 38;
+        public const int WM_PALETTECHANGED = 785;
+        public const int WM_PALETTEISCHANGING = 784;
+        public const int WM_PARENTNOTIFY = 528;
+        public const int WM_PASTE = 770;
+        public const int WM_PENWINFIRST = 896;
+        public const int WM_PENWINLAST = 911;
+        public const int WM_POWER = 72;
+        public const int WM_POWERBROADCAST = 536;
+        public const int WM_PRINT = 791;
+        public const int WM_PRINTCLIENT = 792;
+        public const int WM_QUERYDRAGICON = 55;
+        public const int WM_QUERYENDSESSION = 17;
+        public const int WM_QUERYNEWPALETTE = 783;
+        public const int WM_QUERYOPEN = 19;
+        public const int WM_QUERYUISTATE = 297;
+        public const int WM_QUEUESYNC = 35;
+        public const int WM_QUIT = 18;
+        public const int WM_RBUTTONDBLCLK = 518;
+        public const int WM_RBUTTONDOWN = 516;
+        public const int WM_RBUTTONUP = 517;
+        public const int WM_REFLECT = 8192;
+        public const int WM_RENDERALLFORMATS = 774;
+        public const int WM_RENDERFORMAT = 773;
+        public const int WM_SETCURSOR = 32;
+        public const int WM_SETFOCUS = 7;
+        public const int WM_SETFONT = 48;
+        public const int WM_SETHOTKEY = 50;
+        public const int WM_SETICON = 128;
+        public const int WM_SETREDRAW = 11;
+        public const int WM_SETTEXT = 12;
+        public const int WM_SETTINGCHANGE = 26;
+        public const int WM_SHOWWINDOW = 24;
+        public const int WM_SIZE = 5;
+        public const int WM_SIZECLIPBOARD = 779;
+        public const int WM_SIZING = 532;
+        public const int WM_SPOOLERSTATUS = 42;
+        public const int WM_STYLECHANGED = 125;
+        public const int WM_STYLECHANGING = 124;
+        public const int WM_SYSCHAR = 262;
+        public const int WM_SYSCOLORCHANGE = 21;
+        public const int WM_SYSCOMMAND = 274;
+        public const int WM_SYSDEADCHAR = 263;
+        public const int WM_SYSKEYDOWN = 260;
+        public const int WM_SYSKEYUP = 261;
+        public const int WM_TASKBAR_CREATED = 49286;
+        public const int WM_TCARD = 82;
+        public const int WM_TIMECHANGE = 30;
+        public const int WM_TIMER = 275;
+        public const int WM_TRAYMOUSEMESSAGE = 2048;
+        public const int WM_UNDO = 772;
+        public const int WM_UNINITMENUPOPUP = 293;
+        public const int WM_UPDATEUISTATE = 296;
+        public const int WM_USER = 1024;
+        public const int WM_USERCHANGED = 84;
+        public const int WM_VKEYTOITEM = 46;
+        public const int WM_VSCROLL = 277;
+        public const int WM_VSCROLLCLIPBOARD = 778;
+        public const int WM_WINDOWPOSCHANGED = 71;
+        public const int WM_WINDOWPOSCHANGING = 70;
+        public const int WM_WININICHANGE = 26;
+        public const int WM_XBUTTONDBLCLK = 525;
+        public const int WM_XBUTTONDOWN = 523;
+        public const int WM_XBUTTONUP = 524;
+        public const int WPF_SETMINPOSITION = 1;
+        public const int WS_BORDER = 8388608;
+        public const int WS_CAPTION = 12582912;
+        public const int WS_CHILD = 1073741824;
+        public const int WS_CLIPCHILDREN = 33554432;
+        public const int WS_CLIPSIBLINGS = 67108864;
+        public const int WS_DISABLED = 134217728;
+        public const int WS_DLGFRAME = 4194304;
+        public const int WS_EX_APPWINDOW = 262144;
+        public const int WS_EX_CLIENTEDGE = 512;
+        public const int WS_EX_CONTEXTHELP = 1024;
+        public const int WS_EX_CONTROLPARENT = 65536;
+        public const int WS_EX_DLGMODALFRAME = 1;
+        public const int WS_EX_LAYERED = 524288;
+        public const int WS_EX_LAYOUTRTL = 4194304;
+        public const int WS_EX_LEFT = 0;
+        public const int WS_EX_LEFTSCROLLBAR = 16384;
+        public const int WS_EX_MDICHILD = 64;
+        public const int WS_EX_NOINHERITLAYOUT = 1048576;
+        public const int WS_EX_RIGHT = 4096;
+        public const int WS_EX_RTLREADING = 8192;
+        public const int WS_EX_STATICEDGE = 131072;
+        public const int WS_EX_TOOLWINDOW = 128;
+        public const int WS_EX_TOPMOST = 8;
+        public const int WS_HSCROLL = 1048576;
+        public const int WS_MAXIMIZE = 16777216;
+        public const int WS_MAXIMIZEBOX = 65536;
+        public const int WS_MINIMIZE = 536870912;
+        public const int WS_MINIMIZEBOX = 131072;
+        public const int WS_OVERLAPPED = 0;
+        public const int WS_POPUP = -2147483648;
+        public const int WS_SYSMENU = 524288;
+        public const int WS_TABSTOP = 65536;
+        public const int WS_THICKFRAME = 262144;
+        public const int WS_VISIBLE = 268435456;
+        public const int WS_VSCROLL = 2097152;
+        public const int WSF_VISIBLE = 1;
+    }
+    public class static NativeMethods
+    {
+        public static System.IntPtr GetWindowLong(System.IntPtr hWnd, Topics.Radical.Win32.WindowLong index) { }
+        public static System.IntPtr SetWindowLong(System.IntPtr hWnd, Topics.Radical.Win32.WindowLong index, System.IntPtr value) { }
+    }
+    public enum WindowLong
+    {
+        WindowProc = -4,
+        HInstance = -6,
+        HWndParent = -8,
+        Style = -16,
+        ExStyle = -20,
+        UserData = -21,
+        ID = -12,
+    }
+}

--- a/src/net40/Test.Radical/API/APIApprovals.cs
+++ b/src/net40/Test.Radical/API/APIApprovals.cs
@@ -1,0 +1,24 @@
+﻿using ApprovalTests;
+using ApprovalTests.Reporters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PublicApiGenerator;
+using System.Runtime.CompilerServices;
+using Topics.Radical.ComponentModel.Messaging;
+
+namespace Test.Radical.API
+{
+    [TestClass]
+    public class APIApprovals
+    {
+        [TestMethod]
+        [TestCategory("APIApprovals")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [UseReporter(typeof(DiffReporter))]
+        public void Approve_FXV40_API()
+        {
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(IMessageBroker).Assembly);
+
+            Approvals.Verify(publicApi);
+        }
+    }
+}

--- a/src/net40/Test.Radical/App_Packages/PublicApiGenerator.6.1.0-beta2/ApiGenerator.cs
+++ b/src/net40/Test.Radical/App_Packages/PublicApiGenerator.6.1.0-beta2/ApiGenerator.cs
@@ -1,0 +1,799 @@
+﻿using System;
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CSharp;
+using Mono.Cecil;
+using Mono.Cecil.Rocks;
+using ICustomAttributeProvider = Mono.Cecil.ICustomAttributeProvider;
+using TypeAttributes = System.Reflection.TypeAttributes;
+using System.Globalization;
+
+// ReSharper disable BitwiseOperatorOnEnumWithoutFlags
+namespace PublicApiGenerator
+{
+    public static class ApiGenerator
+    {
+        public static string GeneratePublicApi(Assembly assemby, Type[] includeTypes = null, bool shouldIncludeAssemblyAttributes = true)
+        {
+            using (var assemblyResolver = new DefaultAssemblyResolver())
+            {
+                var assemblyPath = assemby.Location;
+                assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
+
+                var readSymbols = File.Exists(Path.ChangeExtension(assemblyPath, ".pdb"));
+                using (var asm = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters(ReadingMode.Deferred)
+                {
+                    ReadSymbols = readSymbols,
+                    AssemblyResolver = assemblyResolver,
+                }))
+                {
+                    return CreatePublicApiForAssembly(asm, tr => includeTypes == null || includeTypes.Any(t => t.FullName == tr.FullName && t.Assembly.FullName == tr.Module.Assembly.FullName), shouldIncludeAssemblyAttributes);
+                }
+            }
+        }
+
+        // TODO: Assembly references?
+        // TODO: Better handle namespaces - using statements? - requires non-qualified type names
+        static string CreatePublicApiForAssembly(AssemblyDefinition assembly, Func<TypeDefinition, bool> shouldIncludeType, bool shouldIncludeAssemblyAttributes)
+        {
+            var publicApiBuilder = new StringBuilder();
+            var cgo = new CodeGeneratorOptions
+            {
+                BracingStyle = "C",
+                BlankLinesBetweenMembers = false,
+                VerbatimOrder = false
+            };
+
+            using (var provider = new CSharpCodeProvider())
+            {
+                var compileUnit = new CodeCompileUnit();
+                if (shouldIncludeAssemblyAttributes && assembly.HasCustomAttributes)
+                {
+                    PopulateCustomAttributes(assembly, compileUnit.AssemblyCustomAttributes);
+                }
+
+                var publicTypes = assembly.Modules.SelectMany(m => m.GetTypes())
+                    .Where(t => !t.IsNested && ShouldIncludeType(t) && shouldIncludeType(t))
+                    .OrderBy(t => t.FullName);
+                foreach (var publicType in publicTypes)
+                {
+                    var @namespace = compileUnit.Namespaces.Cast<CodeNamespace>()
+                        .FirstOrDefault(n => n.Name == publicType.Namespace);
+                    if (@namespace == null)
+                    {
+                        @namespace = new CodeNamespace(publicType.Namespace);
+                        compileUnit.Namespaces.Add(@namespace);
+                    }
+
+                    var typeDeclaration = CreateTypeDeclaration(publicType);
+                    @namespace.Types.Add(typeDeclaration);
+                }
+
+                using (var writer = new StringWriter())
+                {
+                    provider.GenerateCodeFromCompileUnit(compileUnit, writer, cgo);
+                    var typeDeclarationText = NormaliseGeneratedCode(writer);
+                    publicApiBuilder.AppendLine(typeDeclarationText);
+                }
+            }
+            return NormaliseLineEndings(publicApiBuilder.ToString().Trim());
+        }
+
+        static string NormaliseLineEndings(string value)
+        {
+            return Regex.Replace(value, @"\r\n|\n\r|\r|\n", Environment.NewLine);
+        }
+
+        static bool IsDelegate(TypeDefinition publicType)
+        {
+            return publicType.BaseType != null && publicType.BaseType.FullName == "System.MulticastDelegate";
+        }
+
+        static bool ShouldIncludeType(TypeDefinition t)
+        {
+            return (t.IsPublic || t.IsNestedPublic || t.IsNestedFamily) && !IsCompilerGenerated(t);
+        }
+
+        static bool ShouldIncludeMember(IMemberDefinition m)
+        {
+            return !IsCompilerGenerated(m) && !IsDotNetTypeMember(m) && !(m is FieldDefinition);
+        }
+
+        static bool IsCompilerGenerated(IMemberDefinition m)
+        {
+            return m.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
+        }
+
+        static bool IsDotNetTypeMember(IMemberDefinition m)
+        {
+            if (m.DeclaringType == null || m.DeclaringType.FullName == null)
+                return false;
+            return m.DeclaringType.FullName.StartsWith("System") || m.DeclaringType.FullName.StartsWith("Microsoft");
+        }
+
+        static void AddMemberToTypeDeclaration(CodeTypeDeclaration typeDeclaration, IMemberDefinition memberInfo)
+        {
+            var methodDefinition = memberInfo as MethodDefinition;
+            if (methodDefinition != null)
+            {
+                if (methodDefinition.IsConstructor)
+                    AddCtorToTypeDeclaration(typeDeclaration, methodDefinition);
+                else
+                    AddMethodToTypeDeclaration(typeDeclaration, methodDefinition);
+            }
+            else if (memberInfo is PropertyDefinition)
+            {
+                AddPropertyToTypeDeclaration(typeDeclaration, (PropertyDefinition) memberInfo);
+            }
+            else if (memberInfo is EventDefinition)
+            {
+                typeDeclaration.Members.Add(GenerateEvent((EventDefinition)memberInfo));
+            }
+            else if (memberInfo is FieldDefinition)
+            {
+                AddFieldToTypeDeclaration(typeDeclaration, (FieldDefinition) memberInfo);
+            }
+        }
+
+        static string NormaliseGeneratedCode(StringWriter writer)
+        {
+            var gennedClass = writer.ToString();
+            const string autoGeneratedHeader = @"^//-+\s*$.*^//-+\s*$";
+            const string emptyGetSet = @"\s+{\s+get\s+{\s+}\s+set\s+{\s+}\s+}";
+            const string emptyGet = @"\s+{\s+get\s+{\s+}\s+}";
+            const string emptySet = @"\s+{\s+set\s+{\s+}\s+}";
+            const string getSet = @"\s+{\s+get;\s+set;\s+}";
+            const string get = @"\s+{\s+get;\s+}";
+            const string set = @"\s+{\s+set;\s+}";
+            gennedClass = Regex.Replace(gennedClass, autoGeneratedHeader, string.Empty,
+                RegexOptions.IgnorePatternWhitespace | RegexOptions.Multiline | RegexOptions.Singleline);
+            gennedClass = Regex.Replace(gennedClass, emptyGetSet, " { get; set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, getSet, " { get; set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, emptyGet, " { get; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, emptySet, " { set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, get, " { get; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, set, " { set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, @"\s+{\s+}", " { }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, @"\)\s+;", ");", RegexOptions.IgnorePatternWhitespace);
+            return gennedClass;
+        }
+
+        static CodeTypeDeclaration CreateTypeDeclaration(TypeDefinition publicType)
+        {
+            if (IsDelegate(publicType))
+                return CreateDelegateDeclaration(publicType);
+
+            bool @static = false;
+            TypeAttributes attributes = 0;
+            if (publicType.IsPublic || publicType.IsNestedPublic)
+                attributes |= TypeAttributes.Public;
+            if (publicType.IsNestedFamily)
+                attributes |= TypeAttributes.NestedFamily;
+            if (publicType.IsSealed && !publicType.IsAbstract)
+                attributes |= TypeAttributes.Sealed;
+            else if (!publicType.IsSealed && publicType.IsAbstract && !publicType.IsInterface)
+                attributes |= TypeAttributes.Abstract;
+            else if (publicType.IsSealed && publicType.IsAbstract)
+                @static = true;
+
+            // Static support is a hack. CodeDOM does support it, and this isn't
+            // correct C#, but it's good enough for our API outline
+            var name = publicType.Name;
+
+            var index = name.IndexOf('`');
+            if (index != -1)
+                name = name.Substring(0, index);
+            var declaration = new CodeTypeDeclaration(@static ? "static " + name : name)
+            {
+                CustomAttributes = CreateCustomAttributes(publicType),
+                // TypeAttributes must be specified before the IsXXX as they manipulate TypeAttributes!
+                TypeAttributes = attributes,
+                IsClass = publicType.IsClass,
+                IsEnum = publicType.IsEnum,
+                IsInterface = publicType.IsInterface,
+                IsStruct = publicType.IsValueType && !publicType.IsPrimitive && !publicType.IsEnum,
+            };
+
+            if (declaration.IsInterface && publicType.BaseType != null)
+                throw new NotImplementedException("Base types for interfaces needs testing");
+
+            PopulateGenericParameters(publicType, declaration.TypeParameters);
+
+            if (publicType.BaseType != null && ShouldOutputBaseType(publicType))
+            {
+                if (publicType.BaseType.FullName == "System.Enum")
+                {
+                    var underlyingType = publicType.GetEnumUnderlyingType();
+                    if (underlyingType.FullName != "System.Int32")
+                        declaration.BaseTypes.Add(CreateCodeTypeReference(underlyingType));
+                }
+                else
+                    declaration.BaseTypes.Add(CreateCodeTypeReference(publicType.BaseType));
+            }
+            foreach(var @interface in publicType.Interfaces.OrderBy(i => i.InterfaceType.FullName)
+                .Select(t => new { Reference = t, Definition = t.InterfaceType.Resolve() })
+                .Where(t => ShouldIncludeType(t.Definition))
+                .Select(t => t.Reference))
+                declaration.BaseTypes.Add(CreateCodeTypeReference(@interface.InterfaceType));
+
+            foreach (var memberInfo in publicType.GetMembers().Where(ShouldIncludeMember).OrderBy(m => m.Name))
+                AddMemberToTypeDeclaration(declaration, memberInfo);
+
+            // Fields should be in defined order for an enum
+            var fields = !publicType.IsEnum
+                ? publicType.Fields.OrderBy(f => f.Name)
+                : (IEnumerable<FieldDefinition>)publicType.Fields;
+            foreach (var field in fields)
+                AddMemberToTypeDeclaration(declaration, field);
+
+            foreach (var nestedType in publicType.NestedTypes.Where(ShouldIncludeType).OrderBy(t => t.FullName))
+            {
+                var nestedTypeDeclaration = CreateTypeDeclaration(nestedType);
+                declaration.Members.Add(nestedTypeDeclaration);
+            }
+
+            return declaration;
+        }
+
+        static CodeTypeDeclaration CreateDelegateDeclaration(TypeDefinition publicType)
+        {
+            var invokeMethod = publicType.Methods.Single(m => m.Name == "Invoke");
+            var name = publicType.Name;
+            var index = name.IndexOf('`');
+            if (index != -1)
+                name = name.Substring(0, index);
+            var declaration = new CodeTypeDelegate(name)
+            {
+                Attributes = MemberAttributes.Public,
+                CustomAttributes = CreateCustomAttributes(publicType),
+                ReturnType = CreateCodeTypeReference(invokeMethod.ReturnType),
+            };
+
+            // CodeDOM. No support. Return type attributes.
+            PopulateCustomAttributes(invokeMethod.MethodReturnType, declaration.CustomAttributes, type => ModifyCodeTypeReference(type, "return:"));
+            PopulateGenericParameters(publicType, declaration.TypeParameters);
+            PopulateMethodParameters(invokeMethod, declaration.Parameters);
+
+            // Of course, CodeDOM doesn't support generic type parameters for delegates. Of course.
+            if (declaration.TypeParameters.Count > 0)
+            {
+                var parameterNames = from parameterType in declaration.TypeParameters.Cast<CodeTypeParameter>()
+                    select parameterType.Name;
+                declaration.Name = string.Format(CultureInfo.InvariantCulture, "{0}<{1}>", declaration.Name, string.Join(", ", parameterNames));
+            }
+
+            return declaration;
+        }
+
+        static bool ShouldOutputBaseType(TypeDefinition publicType)
+        {
+            return publicType.BaseType.FullName != "System.Object" && publicType.BaseType.FullName != "System.ValueType";
+        }
+
+        static void PopulateGenericParameters(IGenericParameterProvider publicType, CodeTypeParameterCollection parameters)
+        {
+            foreach (var parameter in publicType.GenericParameters)
+            {
+                if (parameter.HasCustomAttributes)
+                    throw new NotImplementedException("Attributes on type parameters is not supported. And weird");
+
+                // A little hacky. Means we get "in" and "out" prefixed on any constraints, but it's either that
+                // or add it as a custom attribute, which looks even weirder
+                var name = parameter.Name;
+                if (parameter.IsCovariant)
+                    name = "out " + name;
+                if (parameter.IsContravariant)
+                    name = "in " + name;
+
+                var typeParameter = new CodeTypeParameter(name)
+                {
+                    HasConstructorConstraint =
+                        parameter.HasDefaultConstructorConstraint && !parameter.HasNotNullableValueTypeConstraint
+                };
+                if (parameter.HasNotNullableValueTypeConstraint)
+                    typeParameter.Constraints.Add(" struct"); // Extra space is a hack!
+                if (parameter.HasReferenceTypeConstraint)
+                    typeParameter.Constraints.Add(" class");
+                foreach (var constraint in parameter.Constraints.Where(t => t.FullName != "System.ValueType"))
+                {
+                    typeParameter.Constraints.Add(CreateCodeTypeReference(constraint.GetElementType()));
+                }
+                parameters.Add(typeParameter);
+            }
+        }
+
+        static CodeAttributeDeclarationCollection CreateCustomAttributes(ICustomAttributeProvider type)
+        {
+            var attributes = new CodeAttributeDeclarationCollection();
+            PopulateCustomAttributes(type, attributes);
+            return attributes;
+        }
+
+        static void PopulateCustomAttributes(ICustomAttributeProvider type,
+            CodeAttributeDeclarationCollection attributes)
+        {
+            PopulateCustomAttributes(type, attributes, ctr => ctr);
+        }
+
+        static void PopulateCustomAttributes(ICustomAttributeProvider type,
+            CodeAttributeDeclarationCollection attributes, Func<CodeTypeReference, CodeTypeReference> codeTypeModifier)
+        {
+            foreach (var customAttribute in type.CustomAttributes.Where(ShouldIncludeAttribute).OrderBy(a => a.AttributeType.FullName).ThenBy(a => ConvertAttrbuteToCode(codeTypeModifier, a)))
+            {
+                var attribute = GenerateCodeAttributeDeclaration(codeTypeModifier, customAttribute);
+                attributes.Add(attribute);
+            }
+        }
+
+        static CodeAttributeDeclaration GenerateCodeAttributeDeclaration(Func<CodeTypeReference, CodeTypeReference> codeTypeModifier, CustomAttribute customAttribute)
+        {
+            var attribute = new CodeAttributeDeclaration(codeTypeModifier(CreateCodeTypeReference(customAttribute.AttributeType)));
+            foreach (var arg in customAttribute.ConstructorArguments)
+            {
+                attribute.Arguments.Add(new CodeAttributeArgument(CreateInitialiserExpression(arg)));
+            }
+            foreach (var field in customAttribute.Fields.OrderBy(f => f.Name))
+            {
+                attribute.Arguments.Add(new CodeAttributeArgument(field.Name, CreateInitialiserExpression(field.Argument)));
+            }
+            foreach (var property in customAttribute.Properties.OrderBy(p => p.Name))
+            {
+                attribute.Arguments.Add(new CodeAttributeArgument(property.Name, CreateInitialiserExpression(property.Argument)));
+            }
+            return attribute;
+        }
+
+        // Litee: This method is used for additional sorting of custom attributes when multiple values are allowed
+        static object ConvertAttrbuteToCode(Func<CodeTypeReference, CodeTypeReference> codeTypeModifier, CustomAttribute customAttribute)
+        {
+            using (var provider = new CSharpCodeProvider())
+            {
+                var cgo = new CodeGeneratorOptions
+                {
+                    BracingStyle = "C",
+                    BlankLinesBetweenMembers = false,
+                    VerbatimOrder = false
+                };
+                var attribute = GenerateCodeAttributeDeclaration(codeTypeModifier, customAttribute);
+                var declaration = new CodeTypeDeclaration("DummyClass")
+                {
+                    CustomAttributes = new CodeAttributeDeclarationCollection(new[] { attribute }),
+                };
+                using (var writer = new StringWriter())
+                {
+                    provider.GenerateCodeFromType(declaration, writer, cgo);
+                    return writer.ToString();
+                }
+            }
+        }
+
+        static readonly HashSet<string> SkipAttributeNames = new HashSet<string>
+        {
+            "System.CodeDom.Compiler.GeneratedCodeAttribute",
+            "System.ComponentModel.EditorBrowsableAttribute",
+            "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
+            "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
+            "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
+            "System.Runtime.CompilerServices.ExtensionAttribute",
+            "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
+            "System.Reflection.DefaultMemberAttribute",
+            "System.Diagnostics.DebuggableAttribute",
+            "System.Diagnostics.DebuggerNonUserCodeAttribute",
+            "System.Diagnostics.DebuggerStepThroughAttribute",
+            "System.Reflection.AssemblyCompanyAttribute",
+            "System.Reflection.AssemblyConfigurationAttribute",
+            "System.Reflection.AssemblyCopyrightAttribute",
+            "System.Reflection.AssemblyDescriptionAttribute",
+            "System.Reflection.AssemblyFileVersionAttribute",
+            "System.Reflection.AssemblyInformationalVersionAttribute",
+            "System.Reflection.AssemblyProductAttribute",
+            "System.Reflection.AssemblyTitleAttribute",
+            "System.Reflection.AssemblyTrademarkAttribute"
+        };
+
+        static bool ShouldIncludeAttribute(CustomAttribute attribute)
+        {
+            var attributeTypeDefinition = attribute.AttributeType.Resolve();
+            return !SkipAttributeNames.Contains(attribute.AttributeType.FullName) && attributeTypeDefinition.IsPublic;
+        }
+
+        static CodeExpression CreateInitialiserExpression(CustomAttributeArgument attributeArgument)
+        {
+            if (attributeArgument.Value is CustomAttributeArgument)
+            {
+                return CreateInitialiserExpression((CustomAttributeArgument) attributeArgument.Value);
+            }
+
+            if (attributeArgument.Value is CustomAttributeArgument[])
+            {
+                var initialisers = from argument in (CustomAttributeArgument[]) attributeArgument.Value
+                    select CreateInitialiserExpression(argument);
+                return new CodeArrayCreateExpression(CreateCodeTypeReference(attributeArgument.Type), initialisers.ToArray());
+            }
+
+            var type = attributeArgument.Type.Resolve();
+            var value = attributeArgument.Value;
+            if (type.BaseType != null && type.BaseType.FullName == "System.Enum")
+            {
+                var originalValue = Convert.ToInt64(value);
+                if (type.CustomAttributes.Any(a => a.AttributeType.FullName == "System.FlagsAttribute"))
+                {
+                    //var allFlags = from f in type.Fields
+                    //    where f.Constant != null
+                    //    let v = Convert.ToInt64(f.Constant)
+                    //    where v == 0 || (originalValue & v) != 0
+                    //    select (CodeExpression)new CodeFieldReferenceExpression(typeExpression, f.Name);
+                    //return allFlags.Aggregate((current, next) => new CodeBinaryOperatorExpression(current, CodeBinaryOperatorType.BitwiseOr, next));
+
+                    // I'd rather use the above, as it's just using the CodeDOM, but it puts
+                    // brackets around each CodeBinaryOperatorExpression
+                    var flags = from f in type.Fields
+                                where f.Constant != null
+                                let v = Convert.ToInt64(f.Constant)
+                                where v == 0 || (originalValue & v) != 0
+                                select type.FullName + "." + f.Name;
+                    return new CodeSnippetExpression(flags.Aggregate((current, next) => current + " | " + next));
+                }
+
+                var allFlags = from f in type.Fields
+                               where f.Constant != null
+                               let v = Convert.ToInt64(f.Constant)
+                               where v == originalValue
+                               select new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(CreateCodeTypeReference(type)), f.Name);
+                return allFlags.FirstOrDefault();
+            }
+
+            if (type.FullName == "System.Type" && value is TypeReference)
+            {
+                return new CodeTypeOfExpression(CreateCodeTypeReference((TypeReference)value));
+            }
+
+            if (value is string)
+            {
+                // CodeDOM outputs a verbatim string. Any string with \n is treated as such, so normalise
+                // it to make it easier for comparisons
+                value = Regex.Replace((string)value, @"\n", "\\n");
+                value = Regex.Replace((string)value, @"\r\n|\r\\n", "\\r\\n");
+            }
+
+            return new CodePrimitiveExpression(value);
+        }
+
+        static void AddCtorToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member)
+        {
+            if (member.IsAssembly || member.IsPrivate)
+                return;
+
+            var method = new CodeConstructor
+            {
+                CustomAttributes = CreateCustomAttributes(member),
+                Name = member.Name,
+                Attributes = GetMethodAttributes(member)
+            };
+            PopulateMethodParameters(member, method.Parameters);
+
+            typeDeclaration.Members.Add(method);
+        }
+
+        static void AddMethodToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member)
+        {
+            if (member.IsAssembly || member.IsPrivate || member.IsSpecialName)
+                return;
+
+            var returnType = CreateCodeTypeReference(member.ReturnType);
+
+            var method = new CodeMemberMethod
+            {
+                Name = member.Name,
+                Attributes = GetMethodAttributes(member),
+                CustomAttributes = CreateCustomAttributes(member),
+                ReturnType = returnType,
+            };
+            PopulateCustomAttributes(member.MethodReturnType, method.ReturnTypeCustomAttributes);
+            PopulateGenericParameters(member, method.TypeParameters);
+            PopulateMethodParameters(member, method.Parameters, IsExtensionMethod(member));
+
+            typeDeclaration.Members.Add(method);
+        }
+
+        static bool IsExtensionMethod(ICustomAttributeProvider method)
+        {
+            return method.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.ExtensionAttribute");
+        }
+
+        static void PopulateMethodParameters(IMethodSignature member,
+            CodeParameterDeclarationExpressionCollection parameters, bool isExtension = false)
+        {
+            foreach (var parameter in member.Parameters)
+            {
+                FieldDirection direction = 0;
+                if (parameter.IsOut)
+                    direction |= FieldDirection.Out;
+                else if (parameter.ParameterType.IsByReference)
+                    direction |= FieldDirection.Ref;
+
+                var parameterType = parameter.ParameterType.IsByReference
+                    ? parameter.ParameterType.GetElementType()
+                    : parameter.ParameterType;
+
+                var type = CreateCodeTypeReference(parameterType);
+
+                if (isExtension)
+                {
+                    type = ModifyCodeTypeReference(type, "this");
+                    isExtension = false;
+                }
+
+                var name = parameter.HasConstant
+                    ? string.Format(CultureInfo.InvariantCulture, "{0} = {1}", parameter.Name, FormatParameterConstant(parameter))
+                    : parameter.Name;
+                var expression = new CodeParameterDeclarationExpression(type, name)
+                {
+                    Direction = direction,
+                    CustomAttributes = CreateCustomAttributes(parameter)
+                };
+                parameters.Add(expression);
+            }
+        }
+
+        static object FormatParameterConstant(IConstantProvider parameter)
+        {
+            return parameter.Constant is string ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", parameter.Constant) : (parameter.Constant ?? "null");
+        }
+
+        static MemberAttributes GetMethodAttributes(MethodDefinition method)
+        {
+            MemberAttributes access = 0;
+            if (method.IsFamily)
+                access = MemberAttributes.Family;
+            if (method.IsPublic)
+                access = MemberAttributes.Public;
+            if (method.IsAssembly)
+                access = MemberAttributes.Assembly;
+            if (method.IsFamilyAndAssembly)
+                access = MemberAttributes.FamilyAndAssembly;
+            if (method.IsFamilyOrAssembly)
+                access = MemberAttributes.FamilyOrAssembly;
+
+            MemberAttributes scope = 0;
+            if (method.IsStatic)
+                scope |= MemberAttributes.Static;
+            if (method.IsFinal || !method.IsVirtual)
+                scope |= MemberAttributes.Final;
+            if (method.IsAbstract)
+                scope |= MemberAttributes.Abstract;
+            if (method.IsVirtual && !method.IsNewSlot)
+                scope |= MemberAttributes.Override;
+
+            MemberAttributes vtable = 0;
+            if (IsHidingMethod(method))
+                vtable = MemberAttributes.New;
+
+            return access | scope | vtable;
+        }
+
+        static bool IsHidingMethod(MethodDefinition method)
+        {
+            var typeDefinition = method.DeclaringType;
+
+            // If we're an interface, just try and find any method with the same signature
+            // in any of the interfaces that we implement
+            if (typeDefinition.IsInterface)
+            {
+                var interfaceMethods = from @interfaceReference in typeDefinition.Interfaces
+                    let interfaceDefinition = @interfaceReference.InterfaceType.Resolve()
+                    where interfaceDefinition != null
+                    select interfaceDefinition.Methods;
+
+                return interfaceMethods.Any(ms => MetadataResolver.GetMethod(ms, method) != null);
+            }
+
+            // If we're not an interface, find a base method that isn't virtual
+            return !method.IsVirtual && GetBaseTypes(typeDefinition).Any(d => MetadataResolver.GetMethod(d.Methods, method) != null);
+        }
+
+        static IEnumerable<TypeDefinition> GetBaseTypes(TypeDefinition type)
+        {
+            var baseType = type.BaseType;
+            while (baseType != null)
+            {
+                var definition = baseType.Resolve();
+                if (definition == null)
+                    yield break;
+                yield return definition;
+
+                baseType = baseType.DeclaringType;
+            }
+        }
+
+        static void AddPropertyToTypeDeclaration(CodeTypeDeclaration typeDeclaration, PropertyDefinition member)
+        {
+            var getterAttributes = member.GetMethod != null ? GetMethodAttributes(member.GetMethod) : 0;
+            var setterAttributes = member.SetMethod != null ? GetMethodAttributes(member.SetMethod) : 0;
+
+            if (!HasVisiblePropertyMethod(getterAttributes) && !HasVisiblePropertyMethod(setterAttributes))
+                return;
+
+            var propertyAttributes = GetPropertyAttributes(getterAttributes, setterAttributes);
+
+            var propertyType = member.PropertyType.IsGenericParameter
+                ? new CodeTypeReference(member.PropertyType.Name)
+                : CreateCodeTypeReference(member.PropertyType);
+
+            var property = new CodeMemberProperty
+            {
+                Name = member.Name,
+                Type = propertyType,
+                Attributes = propertyAttributes,
+                CustomAttributes = CreateCustomAttributes(member),
+                HasGet = member.GetMethod != null && HasVisiblePropertyMethod(getterAttributes),
+                HasSet = member.SetMethod != null && HasVisiblePropertyMethod(setterAttributes)
+            };
+
+            // Here's a nice hack, because hey, guess what, the CodeDOM doesn't support
+            // attributes on getters or setters
+            if (member.GetMethod != null && member.GetMethod.HasCustomAttributes)
+            {
+                PopulateCustomAttributes(member.GetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "get:"));
+            }
+            if (member.SetMethod != null && member.SetMethod.HasCustomAttributes)
+            {
+                PopulateCustomAttributes(member.SetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "set:"));
+            }
+
+            foreach (var parameter in member.Parameters)
+            {
+                property.Parameters.Add(
+                    new CodeParameterDeclarationExpression(CreateCodeTypeReference(parameter.ParameterType),
+                        parameter.Name));
+            }
+
+            // TODO: CodeDOM has no support for different access modifiers for getters and setters
+            // TODO: CodeDOM has no support for attributes on setters or getters - promote to property?
+
+            typeDeclaration.Members.Add(property);
+        }
+
+        static MemberAttributes GetPropertyAttributes(MemberAttributes getterAttributes, MemberAttributes setterAttributes)
+        {
+            MemberAttributes access = 0;
+            var getterAccess = getterAttributes & MemberAttributes.AccessMask;
+            var setterAccess = setterAttributes & MemberAttributes.AccessMask;
+            if (getterAccess == MemberAttributes.Public || setterAccess == MemberAttributes.Public)
+                access = MemberAttributes.Public;
+            else if (getterAccess == MemberAttributes.Family || setterAccess == MemberAttributes.Family)
+                access = MemberAttributes.Family;
+            else if (getterAccess == MemberAttributes.FamilyAndAssembly || setterAccess == MemberAttributes.FamilyAndAssembly)
+                access = MemberAttributes.FamilyAndAssembly;
+            else if (getterAccess == MemberAttributes.FamilyOrAssembly || setterAccess == MemberAttributes.FamilyOrAssembly)
+                access = MemberAttributes.FamilyOrAssembly;
+            else if (getterAccess == MemberAttributes.Assembly || setterAccess == MemberAttributes.Assembly)
+                access = MemberAttributes.Assembly;
+            else if (getterAccess == MemberAttributes.Private || setterAccess == MemberAttributes.Private)
+                access = MemberAttributes.Private;
+
+            // Scope should be the same for getter and setter. If one isn't specified, it'll be 0
+            var getterScope = getterAttributes & MemberAttributes.ScopeMask;
+            var setterScope = setterAttributes & MemberAttributes.ScopeMask;
+            var scope = (MemberAttributes) Math.Max((int) getterScope, (int) setterScope);
+
+            // Vtable should be the same for getter and setter. If one isn't specified, it'll be 0
+            var getterVtable = getterAttributes & MemberAttributes.VTableMask;
+            var setterVtable = setterAttributes & MemberAttributes.VTableMask;
+            var vtable = (MemberAttributes) Math.Max((int) getterVtable, (int) setterVtable);
+
+            return access | scope | vtable;
+        }
+
+        static bool HasVisiblePropertyMethod(MemberAttributes attributes)
+        {
+            var access = attributes & MemberAttributes.AccessMask;
+            return access == MemberAttributes.Public || access == MemberAttributes.Family ||
+                   access == MemberAttributes.FamilyOrAssembly;
+        }
+
+        static CodeTypeMember GenerateEvent(EventDefinition eventDefinition)
+        {
+            var @event = new CodeMemberEvent
+            {
+                Name = eventDefinition.Name,
+                Attributes = MemberAttributes.Public | MemberAttributes.Final,
+                CustomAttributes = CreateCustomAttributes(eventDefinition),
+                Type = CreateCodeTypeReference(eventDefinition.EventType)
+            };
+
+            return @event;
+        }
+
+        static void AddFieldToTypeDeclaration(CodeTypeDeclaration typeDeclaration, FieldDefinition memberInfo)
+        {
+            if (memberInfo.IsPrivate || memberInfo.IsAssembly || memberInfo.IsSpecialName)
+                return;
+
+            MemberAttributes attributes = 0;
+            if (memberInfo.HasConstant)
+                attributes |= MemberAttributes.Const;
+            if (memberInfo.IsFamily)
+                attributes |= MemberAttributes.Family;
+            if (memberInfo.IsPublic)
+                attributes |= MemberAttributes.Public;
+            if (memberInfo.IsStatic && !memberInfo.HasConstant)
+                attributes |= MemberAttributes.Static;
+
+            // TODO: Values for readonly fields are set in the ctor
+            var codeTypeReference = CreateCodeTypeReference(memberInfo.FieldType);
+            if (memberInfo.IsInitOnly)
+                codeTypeReference = MakeReadonly(codeTypeReference);
+            var field = new CodeMemberField(codeTypeReference, memberInfo.Name)
+            {
+                Attributes = attributes,
+                CustomAttributes = CreateCustomAttributes(memberInfo)
+            };
+
+            if (memberInfo.HasConstant)
+                field.InitExpression = new CodePrimitiveExpression(memberInfo.Constant);
+
+            typeDeclaration.Members.Add(field);
+        }
+
+        static CodeTypeReference MakeReadonly(CodeTypeReference typeReference)
+        {
+            return ModifyCodeTypeReference(typeReference, "readonly");
+        }
+
+        static CodeTypeReference ModifyCodeTypeReference(CodeTypeReference typeReference, string modifier)
+        {
+            using (var provider = new CSharpCodeProvider())
+                return new CodeTypeReference(modifier + " " + provider.GetTypeOutput(typeReference));
+        }
+
+        static CodeTypeReference CreateCodeTypeReference(TypeReference type)
+        {
+            var typeName = GetTypeName(type);
+            return new CodeTypeReference(typeName, CreateGenericArguments(type));
+        }
+
+        static string GetTypeName(TypeReference type)
+        {
+            if (type.IsGenericParameter)
+                return type.Name;
+
+            if (!type.IsNested)
+            {
+                return (!string.IsNullOrEmpty(type.Namespace) ? (type.Namespace + ".") : "") + type.Name;
+            }
+
+            return GetTypeName(type.DeclaringType) + "." + type.Name;
+        }
+
+        static CodeTypeReference[] CreateGenericArguments(TypeReference type)
+        {
+            var genericInstance = type as IGenericInstance;
+            if (genericInstance == null) return null;
+
+            var genericArguments = new List<CodeTypeReference>();
+            foreach (var argument in genericInstance.GenericArguments)
+            {
+                genericArguments.Add(CreateCodeTypeReference(argument));
+            }
+            return genericArguments.ToArray();
+        }
+    }
+
+    static class CecilEx
+    {
+        public static IEnumerable<IMemberDefinition> GetMembers(this TypeDefinition type)
+        {
+            return type.Fields.Cast<IMemberDefinition>()
+                .Concat(type.Methods)
+                .Concat(type.Properties)
+                .Concat(type.Events);
+        }
+    }
+}

--- a/src/net40/Test.Radical/Test.Radical.csproj
+++ b/src/net40/Test.Radical/Test.Radical.csproj
@@ -67,6 +67,8 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="API\APIApprovals.cs" />
+    <Compile Include="App_Packages\PublicApiGenerator.6.1.0-beta2\ApiGenerator.cs" />
     <Compile Include="ChangeTracking\AdvisedActionTests.cs" />
     <Compile Include="ChangeTracking\AdvisoryBuilderTests.cs" />
     <Compile Include="ChangeTracking\AdvisoryTests.cs" />
@@ -196,7 +198,25 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="ApprovalTests, Version=3.0.0.0, Culture=neutral, PublicKeyToken=11bd7d124fc62e0f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ApprovalTests.3.0.13\lib\net40\ApprovalTests.dll</HintPath>
+    </Reference>
+    <Reference Include="ApprovalUtilities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=11bd7d124fc62e0f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ApprovalUtilities.3.0.13\lib\net35\ApprovalUtilities.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
@@ -219,6 +239,9 @@
       <Project>{b48b5bec-de0f-4310-9a36-ff9c07d77acf}</Project>
       <Name>Radical</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="API\APIApprovals.Approve_FXV40_API.approved.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- <Import Project="$(SolutionDir)\.nuget\nuget.targets" /> -->

--- a/src/net40/Test.Radical/packages.config
+++ b/src/net40/Test.Radical/packages.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ApprovalTests" version="3.0.13" targetFramework="net40" />
+  <package id="ApprovalUtilities" version="3.0.13" targetFramework="net40" />
+  <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net40" />
   <package id="Moq" version="4.0.10827" targetFramework="net40" />
+  <package id="PublicApiGenerator" version="6.1.0-beta2" targetFramework="net40" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net40" />
   <package id="SharpTestsEx" version="1.1.1" />
 </packages>

--- a/src/net45/Test.Radical/API/APIApprovals.Approve_FXV45_API.approved.txt
+++ b/src/net45/Test.Radical/API/APIApprovals.Approve_FXV45_API.approved.txt
@@ -1,0 +1,4857 @@
+﻿[assembly: System.CLSCompliantAttribute(true)]
+[assembly: System.Resources.NeutralResourcesLanguageAttribute("en-US", System.Resources.UltimateResourceFallbackLocation.MainAssembly)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Test.Radical35")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Test.Radical40")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Test.Radical45")]
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.InteropServices.GuidAttribute("ac1104e2-8764-42ea-80aa-bfd22bc6a89f")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]
+
+namespace Topics.Radical
+{
+    
+    public sealed class ActionTextWriter : System.IO.TextWriter
+    {
+        public ActionTextWriter(System.Action<string> logger) { }
+        public ActionTextWriter(System.Action<string> logger, System.IFormatProvider formatProvider) { }
+        public override System.Text.Encoding Encoding { get; }
+        public override void Write(string value) { }
+        public override void Write(char[] buffer, int index, int count) { }
+    }
+    public class static ArrayExtensions
+    {
+        public static bool IsSameAs<T>(this T[] source, T[] other)
+            where T : System.IComparable { }
+        public static bool IsSameAs<T>(this T[] source, T[] other, System.Func<T, T, bool> itemComparer) { }
+    }
+    public class BootableFacility : Topics.Radical.ComponentModel.IPuzzleContainerFacility
+    {
+        public BootableFacility() { }
+        public void Initialize(Topics.Radical.ComponentModel.IPuzzleContainer container) { }
+        public void Teardown(Topics.Radical.ComponentModel.IPuzzleContainer container) { }
+    }
+    public class static ConsoleColorExtensions
+    {
+        public static System.IDisposable AsForegroundColor(this System.ConsoleColor color) { }
+    }
+    public class static DateTimeExtensions
+    {
+        public static System.DateTime ToEndOfMonth(this System.DateTime source) { }
+    }
+    public sealed class DelegateComparer<T> : System.Collections.Generic.IComparer<T>
+    
+    {
+        public DelegateComparer(System.Func<T, T, int> comparer) { }
+        public int Compare(T x, T y) { }
+    }
+    public sealed class DelegateEqualityComparer<T> : System.Collections.Generic.EqualityComparer<T>
+    
+    {
+        public DelegateEqualityComparer(System.Func<T, T, bool> comparer, System.Func<T, int> hashCodeFunc) { }
+        public override bool Equals(T x, T y) { }
+        public override int GetHashCode(T obj) { }
+    }
+    public class static EntityCollectionExtensions
+    {
+        public static Topics.Radical.ComponentModel.IEntityCollection<T> BulkLoad<T>(this Topics.Radical.ComponentModel.IEntityCollection<T> list, System.Collections.Generic.IEnumerable<T> data)
+            where T :  class { }
+        public static Topics.Radical.ComponentModel.IEntityCollection<T> BulkLoad<T>(this Topics.Radical.ComponentModel.IEntityCollection<T> list, System.Collections.Generic.IEnumerable<T> data, bool clear)
+            where T :  class { }
+        public static Topics.Radical.ComponentModel.IEntityCollection<T> BulkLoad<T, TSource>(this Topics.Radical.ComponentModel.IEntityCollection<T> list, System.Collections.Generic.IEnumerable<TSource> data, System.Func<TSource, T> adapter)
+            where T :  class { }
+    }
+    public class static EntityViewExtensions
+    {
+        public static Topics.Radical.ComponentModel.IEntityView<T> ApplySimpleSort<T>(this Topics.Radical.ComponentModel.IEntityView<T> view, string property)
+            where T :  class { }
+        public static System.Collections.Generic.IEnumerable<T> AsEntityItems<T>(this Topics.Radical.ComponentModel.IEntityView<T> view)
+            where T :  class { }
+    }
+    public class static EntryBuilder
+    {
+        public static Topics.Radical.ComponentModel.IPuzzleContainerEntry For(System.Type type) { }
+        public static Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> For<T>() { }
+    }
+    public class static EnumExtensions
+    {
+        public static void EnsureIsDefined(this System.Enum value) { }
+        public static string GetCaption(this System.Enum value) { }
+        public static string GetDescription(this System.Enum value) { }
+        public static Topics.Radical.EnumItemDescriptionAttribute GetDescriptionAttribute(this System.Enum value) { }
+        public static bool IsDefined(this System.Enum value) { }
+        public static bool IsDescriptionAttributeDefined(this System.Enum value) { }
+        public static bool TryGetDescriptionAttribute(this System.Enum value, out Topics.Radical.EnumItemDescriptionAttribute attribute) { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    public class EnumItemDescriptionAttribute : System.Attribute
+    {
+        public EnumItemDescriptionAttribute(string caption) { }
+        public EnumItemDescriptionAttribute(string caption, int index) { }
+        public EnumItemDescriptionAttribute(string caption, string description, int index) { }
+        public string Caption { get; }
+        public string Description { get; }
+        public virtual int Index { get; }
+        protected virtual string OnGetCaption(string caption) { }
+        protected virtual string OnGetDescription(string description) { }
+    }
+    public class EnumValueOutOfRangeException : System.ArgumentException
+    {
+        protected EnumValueOutOfRangeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public EnumValueOutOfRangeException() { }
+        public EnumValueOutOfRangeException(string message) { }
+        public EnumValueOutOfRangeException(string message, System.Exception innerException) { }
+    }
+    public class InvalidKeyFormatException : Topics.Radical.RadicalException
+    {
+        protected InvalidKeyFormatException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidKeyFormatException() { }
+        public InvalidKeyFormatException(string message) { }
+        public InvalidKeyFormatException(string message, System.Exception innerException) { }
+    }
+    public class static IServiceProviderExtensions
+    {
+        public static TService GetService<TService>(this System.IServiceProvider serviceProvider) { }
+        public static TInterface GetService<SInterface, TInterface>(this System.IServiceProvider serviceProvider) { }
+        public static TService TryGetService<TService>(this System.IServiceProvider serviceProvider) { }
+        public static TInterface TryGetService<SInterface, TInterface>(this System.IServiceProvider serviceProvider) { }
+    }
+    [System.CLSCompliantAttribute(false)]
+    public abstract class Key : System.IComparable, System.IEquatable<Topics.Radical.ComponentModel.IKey>, Topics.Radical.ComponentModel.IKey
+    {
+        protected Key() { }
+        public abstract bool IsEmpty { get; }
+        public abstract int CompareTo(object obj);
+        public abstract bool Equals(Topics.Radical.ComponentModel.IKey other);
+        public virtual int GetHashCode() { }
+    }
+    [System.CLSCompliantAttribute(false)]
+    public class Key<T> : Topics.Radical.Key, System.IComparable, System.IComparable<Topics.Radical.ComponentModel.IKey<T>>, System.IEquatable<Topics.Radical.ComponentModel.IKey<T>>, System.IEquatable<Topics.Radical.ComponentModel.IKey>, Topics.Radical.ComponentModel.IKey, Topics.Radical.ComponentModel.IKey<T>
+        where T : System.IComparable, System.IComparable<>
+    {
+        public Key() { }
+        public Key(T value) { }
+        public override bool IsEmpty { get; }
+        public T Value { get; }
+        public override int CompareTo(object obj) { }
+        public int CompareTo(Topics.Radical.ComponentModel.IKey<T> other) { }
+        public override bool Equals(object obj) { }
+        public override bool Equals(Topics.Radical.ComponentModel.IKey other) { }
+        public bool Equals(Topics.Radical.ComponentModel.IKey<T> other) { }
+        public static bool Equals(Topics.Radical.ComponentModel.IKey<T> leftValue, Topics.Radical.ComponentModel.IKey<T> rightValue) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+    }
+    public class static KeyExtensions
+    {
+        public static T ValueOr<T>(this Topics.Radical.ComponentModel.IKey value, T defaultValue)
+            where T : System.IComparable, System.IComparable<> { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    public class LocalizableEnumItemDescriptionAttribute : Topics.Radical.EnumItemDescriptionAttribute
+    {
+        public LocalizableEnumItemDescriptionAttribute(string captionKey) { }
+        public LocalizableEnumItemDescriptionAttribute(string captionKey, int index) { }
+        public LocalizableEnumItemDescriptionAttribute(string captionKey, string descriptionKey, int index) { }
+        public Topics.Radical.ResourceAssemblyLocationBehavior AssemblyLocationBehavior { get; set; }
+        public string AssemblyName { get; set; }
+        public string CaptionFallbackValue { get; set; }
+        public string DescriptionFallbackValue { get; set; }
+        protected System.Resources.ResourceManager ResourceManager { get; }
+        public string ResourceName { get; set; }
+        protected override string OnGetCaption(string caption) { }
+        protected override string OnGetDescription(string description) { }
+    }
+    public class MissingContractAttributeException : Topics.Radical.RadicalException
+    {
+        protected MissingContractAttributeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public MissingContractAttributeException() { }
+        public MissingContractAttributeException(System.Type targetType) { }
+        public MissingContractAttributeException(string message) { }
+        public MissingContractAttributeException(string message, System.Exception innerException) { }
+        public System.Type TargetType { get; }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class static NullableExtensions
+    {
+        public static T ValueOr<T>(this System.Nullable<T> value, T defaultValue)
+            where T :  struct { }
+        public static T ValueOr<T>(this System.Nullable<T> value, T defaultValue, System.Func<T, T> ifValue)
+            where T :  struct { }
+    }
+    public class static NumbersExtensions
+    {
+        public static bool IsEven(this int value) { }
+    }
+    public class static ObjectExtensions
+    {
+        public static TInput Do<TInput>(this TInput input, System.Action<TInput> action) { }
+        public static TInput Do<TInput>(this TInput input, System.Predicate<TInput> failureEvaluator, System.Action<TInput> action) { }
+        public static T If<T>(this T obj, System.Predicate<T> condition, System.Action<T> thenAction)
+            where T :  class { }
+        public static T If<T>(this T obj, System.Predicate<T> condition, System.Action<T> thenAction, System.Action<T> elseAction)
+            where T :  class { }
+        public static TInput If<TInput>(this TInput o, System.Func<TInput, bool> evaluator)
+            where TInput :  class { }
+        [System.ObsoleteAttribute()]
+        public static T IfNotNullDo<T>(this T obj, System.Action<T> action) { }
+        [System.ObsoleteAttribute()]
+        public static T IfNullDo<T>(this T obj, System.Action action) { }
+        [System.ObsoleteAttribute()]
+        public static T Intercept<T>(this T obj, System.Action<T> interceptor) { }
+        public static TSource InterceptAs<TSource, TDestination>(this TSource obj, System.Action<TDestination> interceptor)
+            where TSource :  class
+            where TDestination :  class { }
+        public static TResult Return<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator) { }
+        public static TResult Return<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, TResult defaultValueOnNullInput) { }
+        public static TResult Return<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, TResult failureValue, System.Predicate<TInput> failureEvaluator) { }
+        public static TResult Return<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, System.Func<TResult> defaultValueOnNullInput) { }
+        public static TResult Return<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, System.Func<TResult> failureValue, System.Predicate<TInput> failureEvaluator) { }
+        public static TInput Unless<TInput>(this TInput o, System.Func<TInput, bool> evaluator)
+            where TInput :  class { }
+        public static TResult With<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator) { }
+        public static TResult With<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, TResult defaultValueOnNullInput) { }
+        public static TResult With<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, System.Func<TResult> defaultValueOnNullInput) { }
+        public static TResult With<TInput, TResult>(this TInput input, System.Func<TInput, TResult> evaluator, System.Predicate<TInput> failureEvaluator, System.Func<TResult> failureValue) { }
+    }
+    public class Observable<T> : System.ComponentModel.INotifyPropertyChanged
+    
+    {
+        public Observable() { }
+        public Observable(T value) { }
+        public virtual T Value { get; set; }
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        protected virtual void OnPropertyChanged() { }
+    }
+    public class PuzzleContainer : System.IDisposable, Topics.Radical.ComponentModel.IPuzzleContainer
+    {
+        public PuzzleContainer() { }
+        public event System.EventHandler<Topics.Radical.ComponentModel.ComponentRegisteredEventArgs> ComponentRegistered;
+        public Topics.Radical.ComponentModel.IPuzzleContainer AddFacility(Topics.Radical.ComponentModel.IPuzzleContainerFacility facility) { }
+        public Topics.Radical.ComponentModel.IPuzzleContainer AddFacility<TFacility>()
+            where TFacility : Topics.Radical.ComponentModel.IPuzzleContainerFacility { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        protected override void Finalize() { }
+        public System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IPuzzleContainerFacility> GetFacilities() { }
+        public object GetService(System.Type serviceType) { }
+        public bool IsRegistered<TService>() { }
+        public bool IsRegistered(System.Type type) { }
+        protected virtual void OnComponentRegistered(Topics.Radical.ComponentModel.ComponentRegisteredEventArgs e) { }
+        public Topics.Radical.ComponentModel.IPuzzleContainer Register(Topics.Radical.ComponentModel.IContainerEntry entry) { }
+        public Topics.Radical.ComponentModel.IPuzzleContainer Register(System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IContainerEntry> entries) { }
+        public TService Resolve<TService>() { }
+        public object Resolve(System.Type serviceType) { }
+        public object Resolve(string key, System.Type serviceType) { }
+        public System.Collections.Generic.IEnumerable<T> ResolveAll<T>() { }
+        public System.Collections.Generic.IEnumerable<object> ResolveAll(System.Type t) { }
+        public void SetupWith(System.Func<System.Collections.Generic.IEnumerable<System.Type>> knownTypesProvider, params Topics.Radical.ComponentModel.IPuzzleSetupDescriptor[] descriptors) { }
+    }
+    public class PuzzleContainerServiceProviderFacade : System.IServiceProvider
+    {
+        public PuzzleContainerServiceProviderFacade(Topics.Radical.ComponentModel.IPuzzleContainer container) { }
+        public object GetService(System.Type serviceType) { }
+    }
+    public class RadicalException : System.Exception
+    {
+        protected RadicalException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public RadicalException() { }
+        public RadicalException(string message) { }
+        public RadicalException(string message, System.Exception innerException) { }
+    }
+    public enum ResourceAssemblyLocationBehavior
+    {
+        ByAssemblyName = 0,
+        UseExecutingAssembly = 1,
+        UseCallingAssembly = 2,
+        UseEntryAssembly = 3,
+    }
+    public class static StringExtensions
+    {
+        public static string Append(this string value, string text) { }
+        public static System.Collections.Generic.IEnumerable<string> AsKeywords(this string source, params char[] separators) { }
+        public static System.Collections.Generic.IEnumerable<string> AsKeywords(this string source, bool applyWildChardsIfNecessary, params char[] separators) { }
+        public static string AsPackUri(this string resourceRelativeUri) { }
+        public static string AsPackUri(this string resourceRelativeUri, string assemblyName) { }
+        public static string IfNullOrEmptyReturn(this string value, string defaultValue) { }
+        public static bool IsLike(this string value, string pattern) { }
+        public static bool IsLike(this string value, params string[] patterns) { }
+        public static bool IsLike(this string value, string pattern, bool ignoreCase) { }
+        public static bool IsNullOrEmpty(this string value) { }
+        public static string ValueOr(this string value, string defaultValue) { }
+        public static string ValueOr(this string value, string defaultValue, System.Func<string, string> ifValue) { }
+        public static string ValueOrEmpty(this string value) { }
+        public static string ValueOrEmpty(this string value, System.Func<string, string> ifValue) { }
+    }
+    public sealed class SubscribeToMessageFacility : Topics.Radical.ComponentModel.IPuzzleContainerFacility
+    {
+        public SubscribeToMessageFacility() { }
+        public void Initialize(Topics.Radical.ComponentModel.IPuzzleContainer container) { }
+        public void Teardown(Topics.Radical.ComponentModel.IPuzzleContainer container) { }
+    }
+    public class SuspendedChangeTrackingServiceException : Topics.Radical.RadicalException
+    {
+        protected SuspendedChangeTrackingServiceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public SuspendedChangeTrackingServiceException() { }
+        public SuspendedChangeTrackingServiceException(string message) { }
+        public SuspendedChangeTrackingServiceException(string message, System.Exception innerException) { }
+    }
+    public class WeakReference<T> : System.WeakReference
+        where T :  class
+    {
+        public WeakReference(T target) { }
+        public WeakReference(T target, bool trackResurrection) { }
+        protected WeakReference(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public T Target { get; set; }
+    }
+}
+namespace Topics.Radical.Analytics
+{
+    
+    public class AnalyticsEvent
+    {
+        public AnalyticsEvent() { }
+        public object Data { get; set; }
+        public System.DateTimeOffset ExecutedOn { get; set; }
+        public System.Security.Principal.IIdentity Identity { get; set; }
+        public string Name { get; set; }
+    }
+    public class static AnalyticsServices
+    {
+        public static bool IsEnabled { get; set; }
+        public static System.Action<Topics.Radical.Analytics.AnalyticsEvent> UserActionTrackingHandler { get; set; }
+        public static void TrackUserActionAsync(Topics.Radical.Analytics.AnalyticsEvent action) { }
+    }
+}
+namespace Topics.Radical.ChangeTracking
+{
+    
+    public class AdvisedAction : Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction
+    {
+        public AdvisedAction(object target, Topics.Radical.ComponentModel.ChangeTracking.ProposedActions action) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.ProposedActions Action { get; }
+        public object Target { get; }
+    }
+    public class Advisory : Topics.Radical.Collections.ReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction>, System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction>, System.Collections.ICollection, System.Collections.IEnumerable, Topics.Radical.ComponentModel.ChangeTracking.IAdvisory, Topics.Radical.ComponentModel.IReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction>
+    {
+        public Advisory(System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction> actions) { }
+    }
+    public class AdvisoryBuilder : Topics.Radical.ComponentModel.ChangeTracking.IAdvisoryBuilder
+    {
+        public AdvisoryBuilder(Topics.Radical.ComponentModel.ChangeTracking.IChangeSetDistinctVisitor visitor) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GenerateAdvisory(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService svc, Topics.Radical.ComponentModel.ChangeTracking.IChangeSet changeSet) { }
+        protected virtual Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction OnCreateAdvisedAction(object target, Topics.Radical.ComponentModel.ChangeTracking.ProposedActions proposedAction) { }
+    }
+    public class Bookmark : Topics.Radical.ComponentModel.ChangeTracking.IBookmark
+    {
+        public Bookmark(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService owner, Topics.Radical.ComponentModel.ChangeTracking.IChange position, System.Collections.Generic.IEnumerable<object> transientEntities) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Owner { get; }
+        public Topics.Radical.ComponentModel.ChangeTracking.IChange Position { get; }
+        public System.Collections.Generic.IEnumerable<object> TransientEntities { get; }
+    }
+    public abstract class Change<T> : Topics.Radical.ComponentModel.ChangeTracking.IChange, Topics.Radical.ComponentModel.ChangeTracking.IChange<T>
+    
+    {
+        protected Change(object owner, T valueToCache, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> commitCallback, string description) { }
+        public T CachedValue { get; }
+        protected Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> CommitCallback { get; }
+        public string Description { get; }
+        public virtual bool IsCommitSupported { get; }
+        public object Owner { get; }
+        protected Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> RejectCallback { get; }
+        public event System.EventHandler<Topics.Radical.ComponentModel.ChangeTracking.CommittedEventArgs> Committed;
+        public event System.EventHandler<Topics.Radical.ComponentModel.ChangeTracking.RejectedEventArgs> Rejected;
+        public abstract Topics.Radical.ComponentModel.ChangeTracking.IChange Clone();
+        public void Commit(Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason) { }
+        public abstract Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem);
+        public virtual System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+        protected virtual void OnCommit(Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason) { }
+        protected virtual void OnCommitted(Topics.Radical.ComponentModel.ChangeTracking.CommittedEventArgs args) { }
+        protected virtual void OnReject(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        protected virtual void OnRejected(Topics.Radical.ComponentModel.ChangeTracking.RejectedEventArgs args) { }
+        public void Reject(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+    }
+    public class ChangeSet : Topics.Radical.Collections.ReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IChange>, System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IChange>, System.Collections.ICollection, System.Collections.IEnumerable, Topics.Radical.ComponentModel.ChangeTracking.IChangeSet, Topics.Radical.ComponentModel.IReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IChange>
+    {
+        public ChangeSet(System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IChange> changes) { }
+    }
+    public class ChangeSetDistinctVisitor : Topics.Radical.ComponentModel.ChangeTracking.IChangeSetDistinctVisitor
+    {
+        public ChangeSetDistinctVisitor() { }
+        public System.Collections.Generic.IDictionary<object, Topics.Radical.ComponentModel.ChangeTracking.IChange> Visit(Topics.Radical.ComponentModel.ChangeTracking.IChangeSet changeSet) { }
+    }
+    [System.ComponentModel.ToolboxItemAttribute(false)]
+    public class ChangeTrackingService : System.ComponentModel.IChangeTracking, System.ComponentModel.IComponent, System.ComponentModel.IRevertibleChangeTracking, System.IDisposable, Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService
+    {
+        protected static readonly object SyncRoot;
+        public ChangeTrackingService() { }
+        public bool CanRedo { get; }
+        public bool CanUndo { get; }
+        protected System.ComponentModel.EventHandlerList Events { get; }
+        public bool HasTransientEntities { get; }
+        public virtual bool IsChanged { get; }
+        public bool IsDisposed { get; }
+        public bool IsSuspended { get; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+        public System.ComponentModel.ISite Site { get; set; }
+        public event System.EventHandler<System.ComponentModel.CancelEventArgs> AcceptingChanges;
+        public event System.EventHandler ChangesAccepted;
+        public event System.EventHandler ChangesRejected;
+        public event System.EventHandler Disposed;
+        public event System.EventHandler<System.ComponentModel.CancelEventArgs> RejectingChanges;
+        public event System.EventHandler TrackingServiceStateChanged;
+        public virtual void AcceptChanges() { }
+        public virtual void Add(Topics.Radical.ComponentModel.ChangeTracking.IChange change, Topics.Radical.ComponentModel.ChangeTracking.AddChangeBehavior behavior) { }
+        public void Attach(Topics.Radical.ComponentModel.ChangeTracking.IMemento item) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.IAtomicOperation BeginAtomicOperation() { }
+        public virtual Topics.Radical.ComponentModel.ChangeTracking.IBookmark CreateBookmark() { }
+        public void Detach(Topics.Radical.ComponentModel.ChangeTracking.IMemento entity) { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        protected void EnsureNotSuspended() { }
+        protected override void Finalize() { }
+        public virtual Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GetAdvisory() { }
+        public virtual Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GetAdvisory(Topics.Radical.ComponentModel.ChangeTracking.IAdvisoryBuilder builder) { }
+        public virtual Topics.Radical.ComponentModel.ChangeTracking.IChangeSet GetChangeSet() { }
+        public virtual Topics.Radical.ComponentModel.ChangeTracking.IChangeSet GetChangeSet(Topics.Radical.ComponentModel.ChangeTracking.IChangeSetFilter filter) { }
+        public System.Collections.Generic.IEnumerable<object> GetEntities() { }
+        public virtual System.Collections.Generic.IEnumerable<object> GetEntities(Topics.Radical.ComponentModel.ChangeTracking.EntityTrackingStates stateFilter, bool exactMatch) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.EntityPropertyStates GetEntityPropertyState<TEntity, TProperty>(TEntity entity, System.Linq.Expressions.Expression<System.Func<TEntity, TProperty>> property) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.EntityPropertyStates GetEntityPropertyState<TEntity, TProperty>(TEntity entity, string propertyName) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.EntityTrackingStates GetEntityState(object entity) { }
+        protected virtual void OnAcceptingChanges(System.ComponentModel.CancelEventArgs e) { }
+        protected virtual void OnAttach(Topics.Radical.ComponentModel.ChangeTracking.IMemento item) { }
+        protected virtual void OnChangeCommitted(Topics.Radical.ComponentModel.ChangeTracking.IChange change, Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason) { }
+        protected virtual void OnChangeRejected(Topics.Radical.ComponentModel.ChangeTracking.IChange change, Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        protected virtual void OnChangesAccepted() { }
+        protected virtual void OnChangesRejected() { }
+        protected virtual void OnDetach(Topics.Radical.ComponentModel.ChangeTracking.IMemento entity, Topics.Radical.ChangeTracking.ChangeTrackingService.StopTrackingReason reason) { }
+        protected virtual void OnDisposed() { }
+        protected virtual void OnRedo(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        protected virtual void OnRegisterTransient(object entity, bool autoRemove) { }
+        protected virtual void OnRejectingChanges(System.ComponentModel.CancelEventArgs e) { }
+        protected virtual void OnRevert(Topics.Radical.ComponentModel.ChangeTracking.IBookmark bookmark) { }
+        protected virtual void OnTrackingServiceStateChanged() { }
+        protected virtual void OnUndo(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        protected virtual void OnUnregisterTransient(object entity) { }
+        protected virtual void OnUnwire(Topics.Radical.ComponentModel.ChangeTracking.IChange change) { }
+        protected virtual void OnWire(Topics.Radical.ComponentModel.ChangeTracking.IChange change) { }
+        protected virtual void OnWire(System.ComponentModel.IComponent entity) { }
+        public void Redo() { }
+        public void RegisterTransient(object entity) { }
+        public void RegisterTransient(object entity, bool autoRemove) { }
+        public virtual void RejectChanges() { }
+        public virtual void Resume() { }
+        public void Revert(Topics.Radical.ComponentModel.ChangeTracking.IBookmark bookmark) { }
+        public virtual void Suspend() { }
+        public void Undo() { }
+        public void UnregisterTransient(object entity) { }
+        public virtual bool Validate(Topics.Radical.ComponentModel.ChangeTracking.IBookmark bookmark) { }
+        protected enum StopTrackingReason
+        {
+            UserRequest = 0,
+            DisposedEvent = 1,
+        }
+    }
+    public class static ChangeTrackingServiceExtensions
+    {
+        public static T Attach<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service, T source) { }
+        public static System.Collections.Generic.IEnumerable<T> Attach<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service, System.Collections.Generic.IEnumerable<T> data) { }
+        public static System.Collections.Generic.IEnumerable<T> GetChangedItems<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service) { }
+        public static System.Collections.Generic.IEnumerable<T> GetDeletedItems<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service) { }
+        public static System.Collections.Generic.IEnumerable<T> GetNewItems<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service) { }
+        public static System.Collections.Generic.IEnumerable<T> GetRemovedItems<T>(this Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService service) { }
+    }
+    public sealed class IncludeAllChangeSetFilter : Topics.Radical.ComponentModel.ChangeTracking.IChangeSetFilter
+    {
+        public static Topics.Radical.ComponentModel.ChangeTracking.IChangeSetFilter Instance { get; }
+        public bool ShouldInclude(Topics.Radical.ComponentModel.ChangeTracking.IChange change) { }
+    }
+    public class static MementoExtensions
+    {
+        public static bool IsChanged(this Topics.Radical.ComponentModel.ChangeTracking.IMemento entity) { }
+        public static bool IsPropertyValueChanged<TEntity, TProperty>(this TEntity entity, System.Linq.Expressions.Expression<System.Func<TEntity, TProperty>> property)
+            where TEntity : Topics.Radical.ComponentModel.ChangeTracking.IMemento { }
+        public static bool IsTransient(this Topics.Radical.ComponentModel.ChangeTracking.IMemento entity) { }
+    }
+}
+namespace Topics.Radical.ChangeTracking.Specialized
+{
+    
+    public class AddRangeCollectionChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>, T>
+    
+    {
+        public AddRangeCollectionChange(object owner, Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public abstract class CollectionChange<TDescriptor, TItem> : Topics.Radical.ChangeTracking.Change<TDescriptor>, Topics.Radical.ComponentModel.ChangeTracking.IChange
+        where TDescriptor : Topics.Radical.ChangeTracking.Specialized.CollectionChangeDescriptor<>
+    
+    {
+        protected CollectionChange(object owner, TDescriptor descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<TDescriptor> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<TDescriptor> commitCallback, string description) { }
+        public TDescriptor Descriptor { get; }
+    }
+    public abstract class CollectionChangeDescriptor<T>
+    
+    {
+        protected CollectionChangeDescriptor() { }
+    }
+    public class CollectionClearedChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>, T>
+    
+    {
+        public CollectionClearedChange(object owner, Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.CollectionRangeDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public class CollectionRangeDescriptor<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChangeDescriptor<T>
+    
+    {
+        public CollectionRangeDescriptor(System.Collections.Generic.IEnumerable<T> items) { }
+        public System.Collections.Generic.IEnumerable<T> Items { get; }
+    }
+    public class ItemChangedCollectionChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>, T>
+    
+    {
+        public ItemChangedCollectionChange(object owner, Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public class ItemChangedDescriptor<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChangeDescriptor<T>
+    
+    {
+        public ItemChangedDescriptor(T item, int index) { }
+        public int Index { get; }
+        public T Item { get; }
+    }
+    public class ItemMovedCollectionChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.ItemMovedDescriptor<T>, T>
+    
+    {
+        public ItemMovedCollectionChange(object owner, Topics.Radical.ChangeTracking.Specialized.ItemMovedDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.ItemMovedDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.ItemMovedDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public class ItemMovedDescriptor<T> : Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>
+    
+    {
+        public ItemMovedDescriptor(T item, int newIndex, int oldIndex) { }
+        public int NewIndex { get; }
+        public int OldIndex { get; }
+    }
+    public class ItemRemovedCollectionChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>, T>
+    
+    {
+        public ItemRemovedCollectionChange(object owner, Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public class ItemReplacedCollectionChange<T> : Topics.Radical.ChangeTracking.Specialized.CollectionChange<Topics.Radical.ChangeTracking.Specialized.ItemReplacedDescriptor<T>, T>
+    
+    {
+        public ItemReplacedCollectionChange(object owner, Topics.Radical.ChangeTracking.Specialized.ItemReplacedDescriptor<T> descriptor, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<Topics.Radical.ChangeTracking.Specialized.ItemReplacedDescriptor<T>> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<Topics.Radical.ChangeTracking.Specialized.ItemReplacedDescriptor<T>> commitCallback, string description) { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+        public override System.Collections.Generic.IEnumerable<object> GetChangedEntities() { }
+    }
+    public class ItemReplacedDescriptor<T> : Topics.Radical.ChangeTracking.Specialized.ItemChangedDescriptor<T>
+    
+    {
+        public ItemReplacedDescriptor(T newItem, T replacedItem, int index) { }
+        public T NewItem { get; }
+        public T ReplacedItem { get; }
+    }
+    public class PropertyValueChange<T> : Topics.Radical.ChangeTracking.Change<T>, Topics.Radical.ComponentModel.ChangeTracking.IChange, Topics.Radical.ComponentModel.ChangeTracking.IPropertyValueChange
+    
+    {
+        public PropertyValueChange(object owner, string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restoreCallback) { }
+        public PropertyValueChange(object owner, string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restoreCallback, string description) { }
+        public PropertyValueChange(object owner, string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restoreCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> commitCallback, string description) { }
+        public string PropertyName { get; }
+        public override Topics.Radical.ComponentModel.ChangeTracking.IChange Clone() { }
+        public override Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem) { }
+    }
+}
+namespace Topics.Radical.Collections
+{
+    
+    public class ReadOnlyCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable, Topics.Radical.ComponentModel.IReadOnlyCollection<T>
+    
+    {
+        public ReadOnlyCollection(System.Collections.Generic.IEnumerable<T> source) { }
+        public int Count { get; }
+        protected System.Collections.Generic.List<T> InnerList { get; }
+        public bool IsSynchronized { get; }
+        public object SyncRoot { get; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(T[] array, int index) { }
+        public System.Collections.IEnumerator GetEnumerator() { }
+    }
+}
+namespace Topics.Radical.ComponentModel
+{
+    
+    public sealed class ByteArrayTimestamp : Topics.Radical.ComponentModel.Timestamp<byte[]>
+    {
+        public static readonly Topics.Radical.ComponentModel.ByteArrayTimestamp Empty;
+        public ByteArrayTimestamp(byte[] value) { }
+        public override bool Equals(Topics.Radical.ComponentModel.Timestamp obj) { }
+        public override string ToString() { }
+    }
+    public class CollectionChangedEventArgs<T> : System.EventArgs
+    
+    {
+        public CollectionChangedEventArgs(Topics.Radical.ComponentModel.CollectionChangeType changeType) { }
+        public CollectionChangedEventArgs(Topics.Radical.ComponentModel.CollectionChangeType changeType, int index) { }
+        public CollectionChangedEventArgs(Topics.Radical.ComponentModel.CollectionChangeType changeType, int index, int oldIndex, T item) { }
+        public Topics.Radical.ComponentModel.CollectionChangeType ChangeType { get; }
+        public int Index { get; }
+        public T Item { get; }
+        public int OldIndex { get; }
+    }
+    public enum CollectionChangeType
+    {
+        None = 0,
+        SortChanged = 1,
+        ItemAdded = 2,
+        ItemRemoved = 3,
+        ItemChanged = 4,
+        Reset = 5,
+        ItemMoved = 6,
+        ItemReplaced = 7,
+    }
+    public class ComponentRegisteredEventArgs : System.EventArgs
+    {
+        public ComponentRegisteredEventArgs(Topics.Radical.ComponentModel.IContainerEntry entry) { }
+        public Topics.Radical.ComponentModel.IContainerEntry Entry { get; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    public sealed class ContractAttribute : System.Attribute
+    {
+        public ContractAttribute() { }
+        public ContractAttribute(System.Type contractInterface) { }
+        public System.Type ContractInterface { get; }
+    }
+    public class EntityItemViewCustomPropertyDescriptor<T, TValue> : Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T>
+    
+    
+    {
+        public EntityItemViewCustomPropertyDescriptor(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TValue> getter) { }
+        public EntityItemViewCustomPropertyDescriptor(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TValue> getter, Topics.Radical.ComponentModel.EntityItemViewValueSetter<T, TValue> setter) { }
+        public EntityItemViewCustomPropertyDescriptor(string customDisplayName) { }
+        public System.Func<TValue> DafaultValueInterceptor { get; set; }
+        public override string DisplayName { get; }
+        public override bool IsReadOnly { get; }
+        public override string Name { get; }
+        public override System.Type PropertyType { get; }
+        protected Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TValue> ValueGetter { get; }
+        protected Topics.Radical.ComponentModel.EntityItemViewValueSetter<T, TValue> ValueSetter { get; }
+        public TValue GetDefaultValue() { }
+        protected override object GetValueCore(Topics.Radical.ComponentModel.IEntityItemView<T> component) { }
+        protected override void SetValueCore(Topics.Radical.ComponentModel.IEntityItemView<T> component, object value) { }
+    }
+    public class EntityItemViewPropertyDescriptor<T> : System.ComponentModel.PropertyDescriptor
+    
+    {
+        protected EntityItemViewPropertyDescriptor() { }
+        public EntityItemViewPropertyDescriptor(System.Reflection.PropertyInfo property) { }
+        public EntityItemViewPropertyDescriptor(string propertyName) { }
+        public EntityItemViewPropertyDescriptor(string propertyName, string customDisplayName) { }
+        public override System.Type ComponentType { get; }
+        public override string DisplayName { get; }
+        public override bool IsReadOnly { get; }
+        protected System.Reflection.PropertyInfo Property { get; }
+        public override System.Type PropertyType { get; }
+        public override bool CanResetValue(object component) { }
+        public virtual object GetDefaultValue() { }
+        public virtual object GetValue(object component) { }
+        protected virtual object GetValueCore(Topics.Radical.ComponentModel.IEntityItemView<T> component) { }
+        public override void ResetValue(object component) { }
+        public virtual void SetValue(object component, object value) { }
+        protected virtual void SetValueCore(Topics.Radical.ComponentModel.IEntityItemView<T> component, object value) { }
+        public override bool ShouldSerializeValue(object component) { }
+    }
+    public abstract class EntityItemViewValueArgs<T, TValue>
+    
+    
+    {
+        protected EntityItemViewValueArgs(Topics.Radical.ComponentModel.IEntityItemView<T> item, string propertyName) { }
+        public Topics.Radical.ComponentModel.IEntityItemView<T> Item { get; }
+        public string PropertyName { get; }
+    }
+    public delegate object EntityItemViewValueGetter<T, TValue>(Topics.Radical.ComponentModel.EntityItemViewValueGetterArgs<T, TValue> args);
+    public class EntityItemViewValueGetterArgs<T, TValue> : Topics.Radical.ComponentModel.EntityItemViewValueArgs<T, TValue>
+    
+    
+    {
+        public EntityItemViewValueGetterArgs(Topics.Radical.ComponentModel.IEntityItemView<T> item, string propertyName) { }
+    }
+    public delegate void EntityItemViewValueSetter<T, TValue>(Topics.Radical.ComponentModel.EntityItemViewValueSetterArgs<T, TValue> args);
+    public class EntityItemViewValueSetterArgs<T, TValue> : Topics.Radical.ComponentModel.EntityItemViewValueArgs<T, TValue>
+    
+    
+    {
+        public EntityItemViewValueSetterArgs(Topics.Radical.ComponentModel.IEntityItemView<T> item, string propertyName, TValue value) { }
+        public TValue Value { get; }
+    }
+    public interface IAnalyticsServices
+    {
+        bool IsEnabled { get; set; }
+        void TrackUserActionAsync(Topics.Radical.Analytics.AnalyticsEvent action);
+    }
+    public interface IBootable
+    {
+        void Boot();
+    }
+    public interface IContainerEntry
+    {
+        System.Type Component { get; }
+        System.Delegate Factory { get; }
+        bool IsOverridable { get; }
+        string Key { get; }
+        Topics.Radical.ComponentModel.Lifestyle Lifestyle { get; }
+        System.Collections.Generic.IDictionary<string, object> Parameters { get; }
+        System.Collections.Generic.IEnumerable<System.Type> Services { get; }
+    }
+    [Topics.Radical.ComponentModel.ContractAttribute()]
+    public interface IDataContext : System.IDisposable
+    {
+        bool HasPendingChanges { get; }
+        Topics.Radical.ComponentModel.ITransaction Transaction { get; }
+        Topics.Radical.ComponentModel.ITransaction BeginTransaction();
+        Topics.Radical.ComponentModel.ITransaction BeginTransaction(System.Data.IsolationLevel isolationLevel);
+        void Clear();
+        void Delete(object entity);
+        void Detach(object entity);
+        int Execute<TCommand>(TCommand command)
+            where TCommand : Topics.Radical.ComponentModel.QueryModel.IBatchCommand;
+        void FlushChanges();
+        T GetByKey<T>(object key);
+        System.Collections.Generic.IList<TResult> GetByQuery<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec);
+        System.Collections.Generic.IEnumerable<TResult> GetBySpecification<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult> specification);
+        TResult GetScalar<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec);
+        void Insert(object entity);
+        bool IsAttached(object entity);
+        void Save(object entity);
+        void Update(object entity);
+    }
+    public interface IDataContextFactoryProvider
+    {
+        Topics.Radical.ComponentModel.Factories.IDataContextFactory GetDefaultInstance();
+        Topics.Radical.ComponentModel.Factories.IDataContextFactory GetInstance(string name);
+    }
+    public interface IDispatcher
+    {
+        bool IsSafe { get; }
+        void Dispatch(System.Action action);
+        void Dispatch<T>(T arg, System.Action<T> action);
+        void Dispatch<T1, T2>(T1 arg1, T2 arg2, System.Action<T1, T2> action);
+        TResult Dispatch<TResult>(System.Func<TResult> func);
+        void Invoke(System.Delegate d, params object[] args);
+    }
+    public interface IEntityCollection<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.IEnumerable, System.ComponentModel.ISupportInitialize
+    
+    {
+        bool AllowNew { get; }
+        Topics.Radical.ComponentModel.IEntityView<T> DefaultView { get; }
+        bool IsInitializing { get; }
+        public event System.EventHandler<Topics.Radical.ComponentModel.CollectionChangedEventArgs<T>> CollectionChanged;
+        void AddRange(System.Collections.Generic.IEnumerable<T> list);
+        T CreateNew();
+        Topics.Radical.ComponentModel.IEntityView<T> CreateView();
+        void EndInit(bool notify);
+        void Move(int oldIndex, int newIndex);
+        void Move(T item, int newIndex);
+        T[] ToArray();
+    }
+    public interface IEntityItemView : System.ComponentModel.ICustomTypeDescriptor, System.ComponentModel.IEditableObject, System.ComponentModel.INotifyPropertyChanged, Topics.Radical.ComponentModel.INotifyEditableObject
+    {
+        object EntityItem { get; }
+        Topics.Radical.ComponentModel.IEntityView View { get; }
+        void Delete();
+        TValue GetCustomValue<TValue>(string customPropertyName);
+        void NotifyPropertyChanged(string propertyName);
+        void SetCustomValue<TValue>(string customPropertyName, TValue value);
+    }
+    public interface IEntityItemView<T> : System.ComponentModel.ICustomTypeDescriptor, System.ComponentModel.IEditableObject, System.ComponentModel.INotifyPropertyChanged, Topics.Radical.ComponentModel.IEntityItemView, Topics.Radical.ComponentModel.INotifyEditableObject
+    
+    {
+        T EntityItem { get; }
+        Topics.Radical.ComponentModel.IEntityView<T> View { get; }
+    }
+    public interface IEntityItemViewFilter
+    {
+        bool ShouldInclude(object item);
+    }
+    public interface IEntityItemViewFilter<T> : Topics.Radical.ComponentModel.IEntityItemViewFilter
+    
+    {
+        bool ShouldInclude(T item);
+    }
+    public interface IEntityView : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IBindingList, System.ComponentModel.IBindingListView, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.ISupportInitialize, System.ComponentModel.ITypedList
+    {
+        bool AllowMove { get; }
+        System.Collections.IList DataSource { get; }
+        Topics.Radical.ComponentModel.IEntityItemViewFilter Filter { get; set; }
+        bool IsAddingNew { get; }
+        bool IsArrayBased { get; }
+        bool IsFiltered { get; }
+        public event System.EventHandler FilterChanged;
+        public event System.EventHandler SortChanged;
+        void ApplySort(string sortDescriptions);
+        void CancelNew();
+        void CancelNew(int itemIndex);
+        void EndNew();
+        void EndNew(int itemIndex);
+        void Move(int sourceIndex, int newIndex);
+        void Refresh();
+    }
+    public interface IEntityView<T> : System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IEntityItemView<T>>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IBindingList, System.ComponentModel.IBindingListView, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.ISupportInitialize, System.ComponentModel.ITypedList, Topics.Radical.ComponentModel.IEntityView
+    
+    {
+        bool AutoGenerateProperties { get; set; }
+        Topics.Radical.ComponentModel.IEntityItemViewFilter<T> Filter { get; set; }
+        public event System.EventHandler<Topics.Radical.Model.AddingNewEventArgs<T>> AddingNew;
+        Topics.Radical.ComponentModel.IEntityItemView<T> AddNew();
+        Topics.Radical.ComponentModel.IEntityItemView<T> AddNew(System.Action<Topics.Radical.Model.AddingNewEventArgs<T>> addNewInterceptor);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string calculatedPropertyDisplayName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter, Topics.Radical.ComponentModel.EntityItemViewValueSetter<T, TProperty> setter);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string calculatedPropertyDisplayName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string calculatedPropertyDisplayName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter, System.Func<TProperty> defaultValueInterceptor);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(string propertyName, string displayName);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> customProperty);
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(string propertyName);
+        void ApplyFilter(System.Predicate<T> predicate);
+        void ApplySort(System.Collections.Generic.IComparer<Topics.Radical.ComponentModel.IEntityItemView<T>> comparer);
+        System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T>> GetCustomProperties();
+        Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> GetCustomProperty(string name);
+        TValue GetCustomPropertyValue<TValue>(string customPropertyName, Topics.Radical.ComponentModel.IEntityItemView<T> item);
+        System.ComponentModel.PropertyDescriptor GetProperty(string name);
+        bool IsPropertyMappingDefined(string propertyName);
+        void Move(Topics.Radical.ComponentModel.IEntityItemView<T> item, int newIndex);
+        bool RemovePropertyMapping(Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> customProperty);
+        bool RemovePropertyMapping(string propertyName);
+        void SetCustomPropertyValue<TValue>(string customPropertyName, Topics.Radical.ComponentModel.IEntityItemView<T> item, TValue value);
+    }
+    public interface IHaveTimestamp<T>
+    
+    {
+        Topics.Radical.ComponentModel.Timestamp<T> Timestamp { get; set; }
+    }
+    public interface IKey : System.IComparable, System.IEquatable<Topics.Radical.ComponentModel.IKey>
+    {
+        bool IsEmpty { get; }
+    }
+    public interface IKey<T> : System.IComparable, System.IComparable<Topics.Radical.ComponentModel.IKey<T>>, System.IEquatable<Topics.Radical.ComponentModel.IKey<T>>, System.IEquatable<Topics.Radical.ComponentModel.IKey>, Topics.Radical.ComponentModel.IKey
+        where T : System.IComparable, System.IComparable<>
+    {
+        T Value { get; }
+    }
+    public interface IKeyService
+    {
+        Topics.Radical.ComponentModel.IKey GenerateEmpty();
+    }
+    public interface IMonitor
+    {
+        public event System.EventHandler Changed;
+        void NotifyChanged();
+        void StopMonitoring();
+    }
+    public interface IMonitor<T> : Topics.Radical.ComponentModel.IMonitor
+    
+    {
+        T Source { get; }
+    }
+    public interface INotifyEditableObject : System.ComponentModel.IEditableObject
+    {
+        public event System.EventHandler EditBegun;
+        public event System.EventHandler EditCanceled;
+        public event System.EventHandler EditEnded;
+    }
+    public interface IPuzzleContainer : System.IDisposable
+    {
+        public event System.EventHandler<Topics.Radical.ComponentModel.ComponentRegisteredEventArgs> ComponentRegistered;
+        Topics.Radical.ComponentModel.IPuzzleContainer AddFacility(Topics.Radical.ComponentModel.IPuzzleContainerFacility facility);
+        Topics.Radical.ComponentModel.IPuzzleContainer AddFacility<TFacility>()
+            where TFacility : Topics.Radical.ComponentModel.IPuzzleContainerFacility;
+        bool IsRegistered<TService>();
+        bool IsRegistered(System.Type serviceType);
+        Topics.Radical.ComponentModel.IPuzzleContainer Register(System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IContainerEntry> entries);
+        Topics.Radical.ComponentModel.IPuzzleContainer Register(Topics.Radical.ComponentModel.IContainerEntry entry);
+        object Resolve(System.Type serviceType);
+        object Resolve(string key, System.Type serviceType);
+        TService Resolve<TService>();
+        System.Collections.Generic.IEnumerable<T> ResolveAll<T>();
+        System.Collections.Generic.IEnumerable<object> ResolveAll(System.Type t);
+        void SetupWith(System.Func<System.Collections.Generic.IEnumerable<System.Type>> knownTypesProvider, params Topics.Radical.ComponentModel.IPuzzleSetupDescriptor[] descriptors);
+    }
+    public interface IPuzzleContainerEntry : Topics.Radical.ComponentModel.IContainerEntry
+    {
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry Forward(System.Type forwardedType);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry ImplementedBy(System.Type componentType);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry Overridable();
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry UsingFactory(System.Func<object> factory);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry UsingInstance(object instance);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry WithLifestyle(Topics.Radical.ComponentModel.Lifestyle lifestyle);
+    }
+    public interface IPuzzleContainerEntry<T> : Topics.Radical.ComponentModel.IContainerEntry
+    
+    {
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> Forward<TForwarded>();
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> ImplementedBy(System.Type componentType);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> ImplementedBy<TComponent>()
+            where TComponent : T;
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> Overridable();
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> UsingFactory(System.Func<T> factory);
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> UsingInstance<TComponent>(TComponent instance)
+            where TComponent : T;
+        Topics.Radical.ComponentModel.IPuzzleContainerEntry<T> WithLifestyle(Topics.Radical.ComponentModel.Lifestyle lifestyle);
+    }
+    public interface IPuzzleContainerFacility
+    {
+        void Initialize(Topics.Radical.ComponentModel.IPuzzleContainer container);
+        void Teardown(Topics.Radical.ComponentModel.IPuzzleContainer container);
+    }
+    public interface IPuzzleSetupDescriptor
+    {
+        void Setup(Topics.Radical.ComponentModel.IPuzzleContainer container, System.Func<System.Collections.Generic.IEnumerable<System.Type>> knownTypesProvider);
+    }
+    public interface IReadOnlyCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable { }
+    public interface ITransaction : System.IDisposable
+    {
+        void Commit();
+        void Rollback();
+    }
+    public interface IUniqueEntity
+    {
+        Topics.Radical.ComponentModel.IKey Key { get; }
+    }
+    public interface IUniqueEntity<T> : Topics.Radical.ComponentModel.IUniqueEntity
+        where T : System.IComparable, System.IComparable<>
+    {
+        Topics.Radical.ComponentModel.IKey<T> Key { get; }
+    }
+    public enum Lifestyle
+    {
+        Singleton = 0,
+        Transient = 1,
+    }
+    public abstract class Timestamp
+    {
+        protected Timestamp() { }
+        public abstract bool Equals(Topics.Radical.ComponentModel.Timestamp obj);
+        public virtual bool Equals(object obj) { }
+        public virtual int GetHashCode() { }
+    }
+    public class Timestamp<T> : Topics.Radical.ComponentModel.Timestamp
+    
+    {
+        public Timestamp(T value) { }
+        public T Value { get; }
+        public override bool Equals(Topics.Radical.ComponentModel.Timestamp obj) { }
+        public override int GetHashCode() { }
+    }
+}
+namespace Topics.Radical.ComponentModel.ChangeTracking
+{
+    
+    public enum AddChangeBehavior
+    {
+        None = 0,
+        Default = 1,
+        RedoRequest = 2,
+        UndoRequest = 3,
+    }
+    public class ChangeCommittedEventArgs<T> : Topics.Radical.ComponentModel.ChangeTracking.ChangeEventArgs<T>
+    
+    {
+        public ChangeCommittedEventArgs(object entity, T cachedValue, Topics.Radical.ComponentModel.ChangeTracking.IChange source, Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.CommitReason Reason { get; }
+    }
+    public class ChangeEventArgs<T> : System.EventArgs
+    
+    {
+        public ChangeEventArgs(object entity, T cachedValue, Topics.Radical.ComponentModel.ChangeTracking.IChange source) { }
+        public T CachedValue { get; }
+        public object Entity { get; }
+        public Topics.Radical.ComponentModel.ChangeTracking.IChange Source { get; }
+    }
+    public class ChangeRejectedEventArgs<T> : Topics.Radical.ComponentModel.ChangeTracking.ChangeEventArgs<T>
+    
+    {
+        public ChangeRejectedEventArgs(object entity, T cachedValue, Topics.Radical.ComponentModel.ChangeTracking.IChange source, Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.RejectReason Reason { get; }
+    }
+    public enum ChangeTrackingRegistration
+    {
+        AsTransient = 0,
+        AsPersistent = 1,
+    }
+    public delegate void CommitCallback<T>(Topics.Radical.ComponentModel.ChangeTracking.ChangeCommittedEventArgs<T> value);
+    public enum CommitReason
+    {
+        None = 0,
+        AcceptChanges = 1,
+    }
+    public class CommittedEventArgs : System.EventArgs
+    {
+        public CommittedEventArgs(Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.CommitReason Reason { get; }
+    }
+    [System.FlagsAttribute()]
+    public enum EntityPropertyStates
+    {
+        None = 0,
+        Changed = 1,
+        ValueChanged = 2,
+    }
+    [System.FlagsAttribute()]
+    public enum EntityTrackingStates
+    {
+        None = 0,
+        IsTransient = 1,
+        AutoRemove = 2,
+        HasBackwardChanges = 4,
+        HasForwardChanges = 8,
+    }
+    public interface IAdvisedAction
+    {
+        Topics.Radical.ComponentModel.ChangeTracking.ProposedActions Action { get; }
+        object Target { get; }
+    }
+    public interface IAdvisory : System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction>, System.Collections.ICollection, System.Collections.IEnumerable, Topics.Radical.ComponentModel.IReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IAdvisedAction> { }
+    public interface IAdvisoryBuilder
+    {
+        Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GenerateAdvisory(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService svc, Topics.Radical.ComponentModel.ChangeTracking.IChangeSet changeSet);
+    }
+    public interface IAtomicOperation : System.IDisposable
+    {
+        void Complete();
+    }
+    public interface IBookmark
+    {
+        Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Owner { get; }
+        Topics.Radical.ComponentModel.ChangeTracking.IChange Position { get; }
+        System.Collections.Generic.IEnumerable<object> TransientEntities { get; }
+    }
+    public interface IChange
+    {
+        string Description { get; }
+        bool IsCommitSupported { get; }
+        object Owner { get; }
+        public event System.EventHandler<Topics.Radical.ComponentModel.ChangeTracking.CommittedEventArgs> Committed;
+        public event System.EventHandler<Topics.Radical.ComponentModel.ChangeTracking.RejectedEventArgs> Rejected;
+        Topics.Radical.ComponentModel.ChangeTracking.IChange Clone();
+        void Commit(Topics.Radical.ComponentModel.ChangeTracking.CommitReason reason);
+        Topics.Radical.ComponentModel.ChangeTracking.ProposedActions GetAdvisedAction(object changedItem);
+        System.Collections.Generic.IEnumerable<object> GetChangedEntities();
+        void Reject(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason);
+    }
+    public interface IChange<T> : Topics.Radical.ComponentModel.ChangeTracking.IChange
+    
+    {
+        T CachedValue { get; }
+    }
+    public interface IChangeSet : System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.ChangeTracking.IChange>, System.Collections.ICollection, System.Collections.IEnumerable, Topics.Radical.ComponentModel.IReadOnlyCollection<Topics.Radical.ComponentModel.ChangeTracking.IChange> { }
+    public interface IChangeSetDistinctVisitor
+    {
+        System.Collections.Generic.IDictionary<object, Topics.Radical.ComponentModel.ChangeTracking.IChange> Visit(Topics.Radical.ComponentModel.ChangeTracking.IChangeSet changeSet);
+    }
+    public interface IChangeSetFilter
+    {
+        bool ShouldInclude(Topics.Radical.ComponentModel.ChangeTracking.IChange change);
+    }
+    public interface IChangeTrackingService : System.ComponentModel.IChangeTracking, System.ComponentModel.IComponent, System.ComponentModel.IRevertibleChangeTracking, System.IDisposable
+    {
+        bool CanRedo { get; }
+        bool CanUndo { get; }
+        bool HasTransientEntities { get; }
+        bool IsDisposed { get; }
+        bool IsSuspended { get; }
+        public event System.EventHandler<System.ComponentModel.CancelEventArgs> AcceptingChanges;
+        public event System.EventHandler ChangesAccepted;
+        public event System.EventHandler ChangesRejected;
+        public event System.EventHandler<System.ComponentModel.CancelEventArgs> RejectingChanges;
+        public event System.EventHandler TrackingServiceStateChanged;
+        void Add(Topics.Radical.ComponentModel.ChangeTracking.IChange change, Topics.Radical.ComponentModel.ChangeTracking.AddChangeBehavior behavior);
+        void Attach(Topics.Radical.ComponentModel.ChangeTracking.IMemento item);
+        Topics.Radical.ComponentModel.ChangeTracking.IAtomicOperation BeginAtomicOperation();
+        Topics.Radical.ComponentModel.ChangeTracking.IBookmark CreateBookmark();
+        void Detach(Topics.Radical.ComponentModel.ChangeTracking.IMemento entity);
+        Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GetAdvisory();
+        Topics.Radical.ComponentModel.ChangeTracking.IAdvisory GetAdvisory(Topics.Radical.ComponentModel.ChangeTracking.IAdvisoryBuilder builder);
+        Topics.Radical.ComponentModel.ChangeTracking.IChangeSet GetChangeSet();
+        Topics.Radical.ComponentModel.ChangeTracking.IChangeSet GetChangeSet(Topics.Radical.ComponentModel.ChangeTracking.IChangeSetFilter builder);
+        System.Collections.Generic.IEnumerable<object> GetEntities();
+        System.Collections.Generic.IEnumerable<object> GetEntities(Topics.Radical.ComponentModel.ChangeTracking.EntityTrackingStates sateFilter, bool exactMatch);
+        Topics.Radical.ComponentModel.ChangeTracking.EntityPropertyStates GetEntityPropertyState<TEntity, TProperty>(TEntity entity, System.Linq.Expressions.Expression<System.Func<TEntity, TProperty>> property);
+        Topics.Radical.ComponentModel.ChangeTracking.EntityPropertyStates GetEntityPropertyState<TEntity, TProperty>(TEntity entity, string propertyName);
+        Topics.Radical.ComponentModel.ChangeTracking.EntityTrackingStates GetEntityState(object entity);
+        void Redo();
+        void RegisterTransient(object entity);
+        void RegisterTransient(object entity, bool autoRemove);
+        void Resume();
+        void Revert(Topics.Radical.ComponentModel.ChangeTracking.IBookmark bookmark);
+        void Suspend();
+        void Undo();
+        void UnregisterTransient(object entity);
+        bool Validate(Topics.Radical.ComponentModel.ChangeTracking.IBookmark bookmark);
+    }
+    public interface IMemento
+    {
+        Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Memento { get; set; }
+    }
+    public interface IMementoPropertyMetadata
+    {
+        bool TrackChanges { get; set; }
+    }
+    public interface IPropertyValueChange : Topics.Radical.ComponentModel.ChangeTracking.IChange
+    {
+        string PropertyName { get; }
+    }
+    [System.FlagsAttribute()]
+    public enum ProposedActions
+    {
+        None = 0,
+        Create = 1,
+        Update = 2,
+        Delete = 4,
+        Dispose = 8,
+    }
+    public delegate void RejectCallback<T>(Topics.Radical.ComponentModel.ChangeTracking.ChangeRejectedEventArgs<T> value);
+    public class RejectedEventArgs : System.EventArgs
+    {
+        public RejectedEventArgs(Topics.Radical.ComponentModel.ChangeTracking.RejectReason reason) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.RejectReason Reason { get; }
+    }
+    public enum RejectReason
+    {
+        None = 0,
+        Undo = 1,
+        Redo = 2,
+        RejectChanges = 3,
+        Revert = 4,
+    }
+    public enum TransientRegistration
+    {
+        AsTransparent = 0,
+        AsPersistable = 1,
+    }
+}
+namespace Topics.Radical.ComponentModel.Factories
+{
+    
+    public interface IChangeTrackingServiceFactory
+    {
+        Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Create();
+    }
+    [Topics.Radical.ComponentModel.ContractAttribute()]
+    public interface IDataContextFactory
+    {
+        Topics.Radical.ComponentModel.IDataContext Create();
+    }
+    public interface IEntityFactory
+    {
+        T Create<T>(params object[] constructorArguments);
+        object Create(System.Type type, params object[] constructorArguments);
+    }
+}
+namespace Topics.Radical.ComponentModel.Messaging
+{
+    
+    public interface IHandleMessage
+    {
+        void Handle(object sender, object message);
+        bool ShouldHandle(object sender, object message);
+    }
+    [Topics.Radical.ComponentModel.ContractAttribute()]
+    public interface IHandleMessage<T> : Topics.Radical.ComponentModel.Messaging.IHandleMessage
+    
+    {
+        void Handle(object sender, T message);
+    }
+    public interface ILegacyMessageCompatibility
+    {
+        void SetSenderForBackwardCompatibility(object sender);
+    }
+    [System.ObsoleteAttribute("The Radical message broker now supports POCO messages, will be removed in the nex" +
+        "t version.", false)]
+    public interface IMessage : Topics.Radical.ComponentModel.Messaging.ILegacyMessageCompatibility
+    {
+        object Sender { get; }
+    }
+    public interface IMessageBroker
+    {
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Broadcast<T>(T message)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        void Broadcast(object sender, object message);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Broadcast(System.Type messageType, Topics.Radical.ComponentModel.Messaging.IMessage message);
+        System.Threading.Tasks.Task BroadcastAsync(object sender, object message);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Dispatch(Topics.Radical.ComponentModel.Messaging.IMessage message);
+        void Dispatch(object sender, object message);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Dispatch<T>(T message)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Dispatch(System.Type messageType, Topics.Radical.ComponentModel.Messaging.IMessage message);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe<T>(object subscriber, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe(object subscriber, System.Type messageType, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe(object subscriber, object sender, System.Type messageType, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe<T>(object subscriber, object sender, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback);
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage;
+        void Subscribe(object subscriber, object sender, System.Type messageType, System.Action<object, object> callback);
+        void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, object> callback);
+        void Subscribe(object subscriber, System.Type messageType, System.Action<object, object> callback);
+        void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, object> callback);
+        void Subscribe<T>(object subscriber, System.Action<object, T> callback);
+        void Subscribe(object subscriber, object sender, System.Type messageType, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback);
+        void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback);
+        void Subscribe(object subscriber, System.Type messageType, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback);
+        void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback);
+        void Subscribe<T>(object subscriber, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, System.Func<object, T, System.Threading.Tasks.Task> callback);
+        void Subscribe<T>(object subscriber, System.Func<object, T, System.Threading.Tasks.Task<bool>> callbackFilter, System.Func<object, T, System.Threading.Tasks.Task> callback);
+        void Subscribe<T>(object subscriber, object sender, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, object sender, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback);
+        void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback);
+        void Unsubscribe(object subscriber);
+        void Unsubscribe<T>(object subscriber);
+        void Unsubscribe(object subscriber, object sender);
+        void Unsubscribe<T>(object subscriber, object sender);
+        void Unsubscribe<T>(object subscriber, System.Delegate callback);
+    }
+    [System.ObsoleteAttribute("The Radical message broker now supports POCO messages.", false)]
+    public interface IMessageHandler
+    {
+        void Handle(Topics.Radical.ComponentModel.Messaging.IMessage message);
+        bool ShouldHandle(Topics.Radical.ComponentModel.Messaging.IMessage message);
+    }
+    [System.ObsoleteAttribute("The Radical message broker now supports POCO messages.", false)]
+    [Topics.Radical.ComponentModel.ContractAttribute()]
+    public interface IMessageHandler<T> : Topics.Radical.ComponentModel.Messaging.IMessageHandler
+        where T : Topics.Radical.ComponentModel.Messaging.IMessage
+    {
+        void Handle(T message);
+    }
+    public interface INeedSafeSubscription { }
+    public enum InvocationModel
+    {
+        Default = 0,
+        Safe = 1,
+    }
+    public interface IRequireToBeValid
+    {
+        void Validate();
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.All, AllowMultiple=true)]
+    [System.ObsoleteAttribute("Not required anymore, will be removed in the version.", false)]
+    public sealed class SubscribeToMessageAttribute : System.Attribute
+    {
+        public SubscribeToMessageAttribute(System.Type messageType) { }
+        public System.Type MessageType { get; }
+    }
+}
+namespace Topics.Radical.ComponentModel.QueryModel
+{
+    
+    public interface IBatchCommand { }
+    public interface IBatchCommandEngine<TCommand, TProvider>
+        where TCommand : Topics.Radical.ComponentModel.QueryModel.IBatchCommand
+    
+    {
+        int Execute(TCommand command, TProvider provider);
+    }
+    public interface IQueryEngine<TSource, TResult, TProvider>
+    
+    
+    
+    {
+        System.Collections.Generic.IList<TResult> ExecuteQuery(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+    }
+    public interface IQueryEngine<TQuery, TSource, TResult, TProvider> : Topics.Radical.ComponentModel.QueryModel.IQueryEngine<TSource, TResult, TProvider>
+        where TQuery : Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<, >
+    
+    
+    
+    {
+        System.Collections.Generic.IList<TResult> ExecuteQuery(TQuery querySpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+    }
+    public interface IQuerySpecification<T> : Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<T, T>, Topics.Radical.ComponentModel.QueryModel.ISpecification<T, T> { }
+    public interface IQuerySpecification<TSource, TResult> : Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult> { }
+    public interface IQuerySystemManager
+    {
+        Topics.Radical.ComponentModel.QueryModel.IBatchCommandEngine<TCommand, TProvider> GetBatchCommandEngine<TCommand, TProvider>(TCommand command)
+            where TCommand : Topics.Radical.ComponentModel.QueryModel.IBatchCommand
+        ;
+        Topics.Radical.ComponentModel.QueryModel.IQueryEngine<TSource, TResult, TProvider> GetQueryEngine<TSource, TResult, TProvider>(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec);
+        Topics.Radical.ComponentModel.QueryModel.IScalarEvaluator<TSource, TResult, TProvider> GetScalarEvaluator<TSource, TResult, TProvider>(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec);
+    }
+    public interface IScalarEvaluator<TSource, TResult, TProvider>
+    
+    
+    
+    {
+        TResult Evaluate(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+    }
+    public interface IScalarEvaluator<TScalar, TSource, TResult, TProvider> : Topics.Radical.ComponentModel.QueryModel.IScalarEvaluator<TSource, TResult, TProvider>
+        where TScalar : Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<, >
+    
+    
+    
+    {
+        TResult Evaluate(TScalar scalarSpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+    }
+    public interface IScalarSpecification<T> : Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<T, T>, Topics.Radical.ComponentModel.QueryModel.ISpecification<T, T> { }
+    public interface IScalarSpecification<TSource, TResult> : Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult> { }
+    public interface ISpecification<TSource, TResult> { }
+    public class SpecificationNotSupportedException : System.Exception
+    {
+        public SpecificationNotSupportedException() { }
+        public SpecificationNotSupportedException(string message) { }
+        public SpecificationNotSupportedException(string message, System.Exception inner) { }
+        protected SpecificationNotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+}
+namespace Topics.Radical.ComponentModel.Validation
+{
+    
+    public interface IRequireValidationCallback<T>
+    
+    {
+        void OnValidate(Topics.Radical.Validation.ValidationContext<T> context);
+    }
+    public interface IValidator
+    {
+        string RuleSet { get; }
+        bool IsValid(object entity);
+        Topics.Radical.Validation.ValidationResults Validate(object entity);
+        Topics.Radical.Validation.ValidationResults Validate(object entity, string propertyName);
+    }
+    [Topics.Radical.ComponentModel.ContractAttribute()]
+    public interface IValidator<T> : Topics.Radical.ComponentModel.Validation.IValidator
+    
+    {
+        new string RuleSet { get; }
+        Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Action<Topics.Radical.Validation.ValidationContext<T>> rule);
+        Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Linq.Expressions.Expression<System.Func<T, object>> propertyIdentifier, System.Func<Topics.Radical.Validation.ValidationContext<T>, Topics.Radical.ComponentModel.Validation.RuleEvaluation> rule, string error);
+        Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Linq.Expressions.Expression<System.Func<T, object>> propertyIdentifier, System.Func<Topics.Radical.Validation.ValidationContext<T>, Topics.Radical.ComponentModel.Validation.RuleEvaluation> rule, System.Func<Topics.Radical.Validation.ValidationContext<T>, string> error);
+        bool IsValid(T entity);
+        Topics.Radical.Validation.ValidationResults Validate(T entity);
+        Topics.Radical.Validation.ValidationResults Validate(T entity, string propertyName);
+        Topics.Radical.Validation.ValidationResults Validate<TProperty>(T entity, System.Linq.Expressions.Expression<System.Func<T, TProperty>> property);
+    }
+    public interface IValidatorFactory
+    {
+        Topics.Radical.ComponentModel.Validation.IValidator<T> CreateValidator<T>();
+        Topics.Radical.ComponentModel.Validation.IValidator<T> CreateValidator<T>(string ruleSet);
+    }
+    public enum RuleEvaluation
+    {
+        Succeeded = 0,
+        Failed = 1,
+    }
+}
+namespace Topics.Radical.Conversions
+{
+    
+    public class static CastExtensions
+    {
+        public static TResult As<TResult>(this object obj)
+            where TResult :  class { }
+        public static TResult As<TResult>(this object obj, System.Action invalidCastAction)
+            where TResult :  class { }
+        public static TResult As<TResult>(this object obj, System.Action<TResult> validCastAction)
+            where TResult :  class { }
+        public static TResult As<TResult>(this object obj, System.Action<TResult> validCastAction, System.Action invalidCastAction)
+            where TResult :  class { }
+        public static TResult CastTo<TResult>(this object obj) { }
+    }
+    public class static ConvertExtensions
+    {
+        public static Topics.Radical.Observable<T> AsObservable<T>(this T value) { }
+        [System.ObsoleteAttribute()]
+        public static bool ToBoolean(this string value) { }
+        [System.ObsoleteAttribute()]
+        public static decimal ToDecimal(this string value) { }
+        [System.ObsoleteAttribute()]
+        public static decimal ToDecimal(this double value) { }
+        [System.ObsoleteAttribute()]
+        public static int ToInt32(this string value) { }
+    }
+    public class static KeyConversionExtensions
+    {
+        public static Topics.Radical.ComponentModel.IKey<T> AsKey<T>(this T value)
+            where T : System.IComparable, System.IComparable<> { }
+        public static T AsValue<T>(this Topics.Radical.ComponentModel.IKey value)
+            where T : System.IComparable, System.IComparable<> { }
+    }
+}
+namespace Topics.Radical.Data.Adapters
+{
+    
+    public abstract class DataAdapter<TSource, TDestination> : Topics.Radical.Data.Adapters.IDataAdapter<TSource, TDestination>
+    
+    
+    {
+        protected DataAdapter() { }
+        public abstract TDestination Adapt(TSource source);
+        public virtual void Invalidate() { }
+    }
+    public abstract class DataFiller<TSource, TDestination> : Topics.Radical.Data.Adapters.IDataFiller<TSource, TDestination>
+    
+    
+    {
+        protected DataFiller() { }
+        public abstract TDestination Fill(TSource source, TDestination destination);
+        public virtual void Invalidate() { }
+    }
+    public interface IDataAdapter<TSource, TDestination>
+    
+    
+    {
+        TDestination Adapt(TSource source);
+        void Invalidate();
+    }
+    public interface IDataFiller<TSource, TDestination>
+    
+    
+    {
+        TDestination Fill(TSource source, TDestination destination);
+        void Invalidate();
+    }
+}
+namespace Topics.Radical.Data
+{
+    
+    public class DataBase : Topics.Radical.Data.IDataBase
+    {
+        public DataBase(string providerName, string connectionString) { }
+        public DataBase(string providerName, string connectionString, System.Data.CommandType defaultCommandType) { }
+        public DataBase(System.Data.Common.DbConnection connection) { }
+        public DataBase(System.Data.Common.DbConnection connection, System.Data.CommandType defaultCommandType) { }
+        public virtual Topics.Radical.Data.IDataBase AddParameter(System.Data.IDataParameter parameter) { }
+        public virtual Topics.Radical.Data.IDataBase AddParameterRange(System.Collections.Generic.IEnumerable<System.Data.IDataParameter> range) { }
+        public virtual Topics.Radical.Data.IDataBase AddParameterRange(System.Data.IDataParameterCollection range) { }
+        public virtual Topics.Radical.Data.IDataBase As(System.Data.CommandType commandType) { }
+        protected virtual System.Data.IDbCommand CreateCommand(System.Data.IDbConnection connection) { }
+        public virtual int ExecuteNonQuery() { }
+        public T ExecuteReader<T>()
+            where T :  class, System.Data.IDataReader { }
+        public virtual System.Data.IDataReader ExecuteReader() { }
+        public virtual object ExecuteScalar() { }
+        public T ExecuteScalar<T>() { }
+        protected virtual System.Data.IDbConnection GetConnection() { }
+        public virtual Topics.Radical.Data.IDataBase UseCommand(string commandText) { }
+    }
+    [System.ObsoleteAttribute("Use DataBase instead.")]
+    public abstract class DataCommand : System.IDisposable, Topics.Radical.Data.IDataCommand
+    {
+        protected DataCommand(string connString, string cmdText, System.Data.CommandType cmdType) { }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public string CommandText { get; }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public System.Data.CommandType CommandType { get; }
+        protected string ConnectionString { get; }
+        protected System.Collections.Generic.IList<System.Data.IDataParameter> Parameters { get; }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public int ExecuteNonQuery() { }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public int ExecuteNonQuery(string commandText) { }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public object ExecuteScalar() { }
+        [System.ObsoleteAttribute("Use DataBase instead.")]
+        public object ExecuteScalar(string commandText) { }
+        protected override void Finalize() { }
+        protected virtual Topics.Radical.Data.IDataCommand OnAddParameter(System.Data.IDataParameter parameter) { }
+        protected virtual Topics.Radical.Data.IDataCommand OnAddParameterRange(System.Collections.Generic.IEnumerable<System.Data.IDataParameter> range) { }
+        protected Topics.Radical.Data.IDataCommand OnCommand(string commandText) { }
+        protected abstract System.Data.IDbCommand OnCreateCommand(System.Data.IDbConnection connection);
+        protected virtual void OnDisposeConnection(System.Data.IDbConnection connection) { }
+        protected virtual int OnExecuteNonQuery(string commandText) { }
+        protected System.Data.IDataReader OnExecuteReader(string commandText) { }
+        protected object OnExecuteScalar(string commandText) { }
+        protected abstract System.Data.IDbConnection OnGetConnection(ref bool shouldDisposeConnectio);
+        protected Topics.Radical.Data.IDataCommand OnType(System.Data.CommandType commandType) { }
+    }
+    public interface IDataBase
+    {
+        Topics.Radical.Data.IDataBase AddParameter(System.Data.IDataParameter parameter);
+        Topics.Radical.Data.IDataBase AddParameterRange(System.Collections.Generic.IEnumerable<System.Data.IDataParameter> range);
+        Topics.Radical.Data.IDataBase AddParameterRange(System.Data.IDataParameterCollection range);
+        Topics.Radical.Data.IDataBase As(System.Data.CommandType commandType);
+        int ExecuteNonQuery();
+        System.Data.IDataReader ExecuteReader();
+        T ExecuteReader<T>()
+            where T :  class, System.Data.IDataReader;
+        object ExecuteScalar();
+        T ExecuteScalar<T>();
+        Topics.Radical.Data.IDataBase UseCommand(string commandText);
+    }
+    public interface IDataBaseProvider
+    {
+        Topics.Radical.Data.IDataBase ConnectingTo(string connectionString);
+        Topics.Radical.Data.IDataBase ConnectingTo(System.Data.Common.DbConnection connection);
+    }
+    [System.ObsoleteAttribute("Use IDataBase instead.")]
+    public interface IDataCommand : System.IDisposable
+    {
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        string CommandText { get; }
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        System.Data.CommandType CommandType { get; }
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        Topics.Radical.Data.IDataCommand AddParameter(System.Data.IDataParameter parameter);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        Topics.Radical.Data.IDataCommand AddParameterRange(System.Collections.Generic.IEnumerable<System.Data.IDataParameter> range);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        Topics.Radical.Data.IDataCommand Command(string commandText);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        int ExecuteNonQuery();
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        int ExecuteNonQuery(string commandText);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        System.Data.IDataReader ExecuteReader();
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        System.Data.IDataReader ExecuteReader(string commandText);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        object ExecuteScalar();
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        object ExecuteScalar(string commandText);
+        [System.ObsoleteAttribute("Use IDataBase instead.")]
+        Topics.Radical.Data.IDataCommand Type(System.Data.CommandType commandType);
+    }
+}
+namespace Topics.Radical.Data.SqlServer
+{
+    
+    public class static KeywordsExtensions
+    {
+        public static string AsSqlServerKeyword(this string keyword) { }
+        public static System.Collections.Generic.IEnumerable<string> AsSqlServerKeywords(this System.Collections.Generic.IEnumerable<string> keywords) { }
+    }
+}
+namespace Topics.Radical.DataBinding
+{
+    
+    public class EnumBinder<T>
+    
+    {
+        public EnumBinder(Topics.Radical.EnumItemDescriptionAttribute attribute, T value) { }
+        public EnumBinder(string caption, T value) { }
+        public EnumBinder(string caption, T value, int index) { }
+        public EnumBinder(string caption, string description, T value, int index) { }
+        public string Caption { get; }
+        public string Description { get; }
+        public int Index { get; }
+        public T Value { get; }
+    }
+}
+namespace Topics.Radical.Diagnostics
+{
+    
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.All, AllowMultiple=false)]
+    public sealed class BuildAttribute : System.Attribute
+    {
+        public BuildAttribute(bool isOptimized) { }
+        public bool IsOptimized { get; }
+        public string Version { get; set; }
+    }
+    public class static EnsurePreviewExtensions
+    {
+        public static Topics.Radical.Validation.IEnsure<T> LogErrorsTo<T>(this Topics.Radical.Validation.IEnsure<T> validator, System.Diagnostics.TraceSource logger) { }
+    }
+    public sealed class New : System.IDisposable
+    {
+        public void Dispose() { }
+        public static System.IDisposable LogicalOperation(object operationId) { }
+    }
+    public class ObjectDumper : System.IDisposable
+    {
+        public void Dispose() { }
+        public static string Dump(object target) { }
+        public static string Dump(object target, int depth) { }
+        public override string ToString() { }
+    }
+    public class static TraceSourceExtensions
+    {
+        public static void Debug(this System.Diagnostics.TraceSource source, int eventId, string message) { }
+        public static void Debug(this System.Diagnostics.TraceSource source, int eventId, string format, params object[] args) { }
+        public static void Debug(this System.Diagnostics.TraceSource source, string message) { }
+        public static void Debug(this System.Diagnostics.TraceSource source, string format, params object[] args) { }
+        public static void Debug(this System.Diagnostics.TraceSource source, string format, System.Func<object[]> args) { }
+        public static void Error(this System.Diagnostics.TraceSource source, string message) { }
+        public static void Error(this System.Diagnostics.TraceSource source, string format, params object[] args) { }
+        public static void Error(this System.Diagnostics.TraceSource source, string message, System.Exception e) { }
+        public static void Error(this System.Diagnostics.TraceSource source, string message, System.Exception e, bool dumpException) { }
+        public static void Information(this System.Diagnostics.TraceSource source, int eventId, string message) { }
+        public static void Information(this System.Diagnostics.TraceSource source, int eventId, string format, params object[] args) { }
+        public static void Information(this System.Diagnostics.TraceSource source, string message) { }
+        public static void Information(this System.Diagnostics.TraceSource source, string format, params object[] args) { }
+        [System.ObsoleteAttribute()]
+        public static void Verbose(this System.Diagnostics.TraceSource source, int eventId, string message) { }
+        [System.ObsoleteAttribute()]
+        public static void Verbose(this System.Diagnostics.TraceSource source, int eventId, string format, params object[] args) { }
+        [System.ObsoleteAttribute()]
+        public static void Verbose(this System.Diagnostics.TraceSource source, string message) { }
+        [System.ObsoleteAttribute()]
+        public static void Verbose(this System.Diagnostics.TraceSource source, string format, params object[] args) { }
+        [System.ObsoleteAttribute()]
+        public static void Verbose(this System.Diagnostics.TraceSource source, string format, System.Func<object[]> args) { }
+        public static void Warning(this System.Diagnostics.TraceSource source, string message) { }
+        public static void Warning(this System.Diagnostics.TraceSource source, string format, params object[] args) { }
+    }
+}
+namespace Topics.Radical.Helpers
+{
+    
+    public class CommandLine
+    {
+        public CommandLine(System.Collections.Generic.IEnumerable<string> args) { }
+        public T As<T>()
+            where T :  class, new () { }
+        public static string AsArguments<T>(T source) { }
+        public bool Contains(string arg) { }
+        public static Topics.Radical.Helpers.CommandLine GetCurrent() { }
+        public bool TryGetValue<T>(string arg, out T value) { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property | System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    public sealed class CommandLineArgumentAttribute : System.Attribute
+    {
+        public CommandLineArgumentAttribute(string argumentName) { }
+        public string[] Aliases { get; set; }
+        public string ArgumentName { get; }
+        public bool IsRequired { get; set; }
+    }
+    public class static EnumHelper
+    {
+        public static System.Collections.Generic.IEnumerable<Topics.Radical.DataBinding.EnumBinder<T>> ExtractBindingData<T>() { }
+        public static System.Collections.Generic.IEnumerable<Topics.Radical.DataBinding.EnumBinder<T>> ExtractBindingData<T>(System.Predicate<T> filter) { }
+        public static System.Collections.Generic.IEnumerable<string> ExtractDescriptions<T>() { }
+        public static System.Collections.Generic.IEnumerable<T> GetValues<T>() { }
+        public static System.Collections.Generic.IEnumerable<object> GetValues(System.Type enumType) { }
+    }
+    public class HashCodeBuilder
+    {
+        public HashCodeBuilder(long initialHashCode) { }
+        public long CombinedHash { get; }
+        public int CombinedHash32 { get; }
+        public void AddObject(object value) { }
+    }
+    public class static KnownRegex
+    {
+        public static readonly string MailAddress;
+        public static readonly string Url;
+        public class static CreditCards
+        {
+            public static readonly string AmericanExpress;
+            public static readonly string Diners;
+            public static readonly string Discover;
+            public static readonly string JCB;
+            public static readonly string MasterCard;
+            public static readonly string Visa;
+        }
+    }
+    public class OSHelper
+    {
+        public OSHelper() { }
+        public int GetOSArchitecture() { }
+        public string GetOSInfo() { }
+    }
+    public class static Password
+    {
+        public static byte[] CreateHash(string clearTextPassword, byte[] passwordSalt) { }
+        public static byte[] CreateHash(string clearTextPassword, byte[] passwordSalt, string hashAlgorithmName) { }
+        public static byte[] CreateRandomSalt() { }
+    }
+    public class RandomStrings
+    {
+        public RandomStrings() { }
+        public bool AllowConsecutiveCharacters { get; set; }
+        public bool AllowRepeatCharacters { get; set; }
+        public bool AllowSymbols { get; set; }
+        public System.Collections.Generic.List<char> Exclusions { get; }
+        public int MaxLenght { get; set; }
+        public int MinLenght { get; set; }
+        public static string GenerateRandom() { }
+        protected int GetCryptographicRandomNumber(int lBound, int uBound) { }
+        protected char GetRandomCharacter() { }
+        public string Next() { }
+    }
+    public class static ReflectionHelper
+    {
+        public static Topics.Radical.Helpers.ReflectionHelper.BoundReflectionHelper<T> BoundTo<T>() { }
+        public static string GetPropertyName<T>(System.Linq.Expressions.Expression<System.Func<T, object>> propertyRef) { }
+        public class BoundReflectionHelper<T>
+        
+        {
+            public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetProperties(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression) { }
+            public System.Reflection.PropertyInfo GetProperty(System.Linq.Expressions.Expression<System.Func<T, object>> propertyRef) { }
+            public string NameOf(System.Linq.Expressions.Expression<System.Func<T, object>> propertyRef) { }
+        }
+    }
+}
+namespace Topics.Radical.Linq
+{
+    
+    public class static EnumerableExtensions
+    {
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(Topics.Radical.Linq.EnumerableExtensions.<AlternateWith>d__13<>))]
+        public static System.Collections.Generic.IEnumerable<T> AlternateWith<T>(this System.Collections.Generic.IEnumerable<T> items, T separator) { }
+        public static bool Any(this System.Collections.IEnumerable source) { }
+        public static System.Collections.Generic.IEnumerable<T> AsReadOnly<T>(this System.Collections.Generic.IEnumerable<T> list) { }
+        public static System.Collections.IEnumerable Enumerate(this System.Collections.IEnumerable list, System.Action<object> action) { }
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(Topics.Radical.Linq.EnumerableExtensions.<FindNodes>d__2<>))]
+        public static System.Collections.Generic.IEnumerable<T> FindNodes<T>(this System.Collections.Generic.IEnumerable<T> source, System.Func<T, System.Collections.Generic.IEnumerable<T>> childrenGetter, System.Func<T, bool> condition) { }
+        public static System.Collections.Generic.IEnumerable<T> ForEach<T>(this System.Collections.Generic.IEnumerable<T> list, System.Action<T> action) { }
+        public static System.Collections.Generic.IEnumerable<T> ForEach<TState, T>(this System.Collections.Generic.IEnumerable<T> list, TState initialState, System.Func<TState, T, TState> func) { }
+        public static bool IsChildOfAny<T>(this T item, System.Collections.Generic.IEnumerable<T> parents, System.Func<T, T> parentGetter)
+            where T :  class { }
+        public static bool IsChildOfAny<T>(this T item, System.Collections.Generic.IEnumerable<T> parents, System.Func<T, T> parentGetter, System.Func<T, T, bool> comparer) { }
+        public static bool IsChildOfAny<T>(this T item, System.Collections.Generic.IEnumerable<T> parents, System.Func<T, T> parentGetter, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public static bool None<T>(this System.Collections.Generic.IEnumerable<T> source) { }
+        public static bool None(this System.Collections.IEnumerable source) { }
+        public static System.Collections.Generic.IEnumerable<T> Shouffle<T>(this System.Collections.Generic.IEnumerable<T> items) { }
+        public static System.Collections.Generic.IEnumerable<T> ToFlat<T>(this T root, System.Func<T, System.Collections.Generic.IEnumerable<T>> childrenGetter)
+            where T :  class { }
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(Topics.Radical.Linq.EnumerableExtensions.<ToFlat>d__1<>))]
+        public static System.Collections.Generic.IEnumerable<T> ToFlat<T>(this System.Collections.Generic.IEnumerable<T> source, System.Func<T, System.Collections.Generic.IEnumerable<T>> childrenGetter) { }
+    }
+    public class static ExpressionExtensions
+    {
+        public static string GetMemberName<T>(this System.Linq.Expressions.Expression<System.Func<T>> source) { }
+        public static string GetMemberName<T, TProperty>(this System.Linq.Expressions.Expression<System.Func<T, TProperty>> source) { }
+    }
+    public class static ListExtensions
+    {
+        public static System.Collections.Generic.IList<T> Sync<T>(this System.Collections.Generic.IList<T> source, System.Collections.Generic.IList<T> destination) { }
+    }
+    public class static PredicateBuilder
+    {
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> And<T>(this System.Linq.Expressions.Expression<System.Func<T, bool>> expr1, System.Linq.Expressions.Expression<System.Func<T, bool>> expr2) { }
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> AndIf<T>(this System.Linq.Expressions.Expression<System.Func<T, bool>> expr1, System.Func<bool> condition, System.Linq.Expressions.Expression<System.Func<T, bool>> expr2) { }
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> False<T>() { }
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> Or<T>(this System.Linq.Expressions.Expression<System.Func<T, bool>> expr1, System.Linq.Expressions.Expression<System.Func<T, bool>> expr2) { }
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> True<T>() { }
+    }
+    public class static QueryableExtensions
+    {
+        public static Topics.Radical.ComponentModel.IEntityCollection<TDest> Fill<TSource, TDest>(this System.Linq.IQueryable<TSource> source, Topics.Radical.ComponentModel.IEntityCollection<TDest> destination, System.Func<TSource, TDest> adapter)
+        
+            where TDest :  class { }
+        public static Topics.Radical.ComponentModel.IEntityCollection<TDest> Fill<TSource, TDest>(this System.Linq.IQueryable<TSource> source, Topics.Radical.ComponentModel.IEntityCollection<TDest> destination, System.Func<TSource, Topics.Radical.ComponentModel.IEntityCollection<TDest>, TDest> adapter)
+        
+            where TDest :  class { }
+    }
+    public class static SelectorExtensions
+    {
+        public static T FirstOr<T>(this System.Collections.Generic.IEnumerable<T> source, System.Func<T> defaultValue) { }
+        public static T SingleOr<T>(this System.Collections.Generic.IEnumerable<T> source, System.Func<T> defaultValue) { }
+    }
+}
+namespace Topics.Radical.Messaging
+{
+    
+    public abstract class AbstractMessageHandler<T> : Topics.Radical.ComponentModel.Messaging.IHandleMessage, Topics.Radical.ComponentModel.Messaging.IHandleMessage<T>
+    
+    {
+        protected AbstractMessageHandler() { }
+        public abstract void Handle(object sender, T message);
+        public virtual void Handle(object sender, object message) { }
+        protected virtual bool OnShouldHandle(object sender, T message) { }
+        public bool ShouldHandle(object sender, object message) { }
+    }
+    [System.ObsoleteAttribute("The Radical message broker now supports POCO messages, will be removed in the nex" +
+        "t version.", false)]
+    public abstract class Message : Topics.Radical.ComponentModel.Messaging.ILegacyMessageCompatibility, Topics.Radical.ComponentModel.Messaging.IMessage
+    {
+        protected Message() { }
+        [System.ObsoleteAttribute("The Radical message broker now supports POCO messages, use the default contructor" +
+            ", will be removed in the next version.", false)]
+        protected Message(object sender) { }
+        public object Sender { get; }
+    }
+    public class MessageBroker : Topics.Radical.ComponentModel.Messaging.IMessageBroker
+    {
+        public MessageBroker(Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        public MessageBroker(Topics.Radical.ComponentModel.IDispatcher dispatcher, System.Threading.Tasks.TaskFactory factory) { }
+        public void Broadcast<T>(T message)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Broadcast(System.Type messageType, Topics.Radical.ComponentModel.Messaging.IMessage message) { }
+        public void Broadcast(object sender, object message) { }
+        public System.Threading.Tasks.Task BroadcastAsync(object sender, object message) { }
+        public void Dispatch<T>(T message)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Dispatch(Topics.Radical.ComponentModel.Messaging.IMessage message) { }
+        public void Dispatch(System.Type messageType, Topics.Radical.ComponentModel.Messaging.IMessage message) { }
+        public void Dispatch(object sender, object message) { }
+        public void Subscribe<T>(object subscriber, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Subscribe<T>(object subscriber, System.Action<object, T> callback) { }
+        public void Subscribe<T>(object subscriber, object sender, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Subscribe<T>(object subscriber, object sender, System.Action<object, T> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, System.Action<object, object> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, System.Action<object, object> callback) { }
+        public void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, T> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, object> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<Topics.Radical.ComponentModel.Messaging.IMessage> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, object> callback) { }
+        public void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<T> callback)
+            where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Action<object, T> callback) { }
+        public void Subscribe<T>(object subscriber, System.Func<object, T, System.Threading.Tasks.Task> callback) { }
+        public void Subscribe<T>(object subscriber, System.Func<object, T, System.Threading.Tasks.Task<bool>> callbackFilter, System.Func<object, T, System.Threading.Tasks.Task> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback) { }
+        public void Subscribe(object subscriber, object sender, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback) { }
+        public void Subscribe(object subscriber, System.Type messageType, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, object, bool> callbackFilter, System.Action<object, object> callback) { }
+        public void Subscribe<T>(object subscriber, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback) { }
+        public void Subscribe<T>(object subscriber, object sender, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback) { }
+        public void Subscribe<T>(object subscriber, object sender, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback) { }
+        public void Subscribe<T>(object subscriber, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel, System.Func<object, T, bool> callbackFilter, System.Action<object, T> callback) { }
+        public void Unsubscribe(object subscriber) { }
+        public void Unsubscribe(object subscriber, object sender) { }
+        public void Unsubscribe<T>(object subscriber) { }
+        public void Unsubscribe<T>(object subscriber, object sender) { }
+        public void Unsubscribe<T>(object subscriber, System.Delegate callback) { }
+    }
+    [System.ObsoleteAttribute("The Radical message broker now supports POCO messages, inherits from AbstractMess" +
+        "ageHandler<T> or implement IHandleMessage<T> interface directly.", false)]
+    public abstract class MessageHandler<T> : Topics.Radical.ComponentModel.Messaging.IMessageHandler, Topics.Radical.ComponentModel.Messaging.IMessageHandler<T>
+        where T :  class, Topics.Radical.ComponentModel.Messaging.IMessage
+    {
+        protected MessageHandler() { }
+        public abstract void Handle(T message);
+        public virtual void Handle(Topics.Radical.ComponentModel.Messaging.IMessage message) { }
+        protected virtual bool OnShouldHandle(T message) { }
+        public bool ShouldHandle(Topics.Radical.ComponentModel.Messaging.IMessage message) { }
+    }
+    public enum SubscriptionPriority
+    {
+        Highest = 3,
+        High = 2,
+        AboveNormal = 1,
+        Normal = 0,
+        BelowNormal = -1,
+        Low = -2,
+        Lowest = -3,
+    }
+}
+namespace Topics.Radical.Model
+{
+    
+    public class AddingNewEventArgs<T> : System.ComponentModel.CancelEventArgs
+    
+    {
+        public AddingNewEventArgs() { }
+        public bool AutoCommit { get; set; }
+        public T NewItem { get; set; }
+    }
+    public abstract class Entity : System.ComponentModel.INotifyPropertyChanged, System.IDisposable
+    {
+        protected Entity() { }
+        protected System.ComponentModel.EventHandlerList Events { get; }
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        protected virtual void EnsureNotDisposed() { }
+        protected override void Finalize() { }
+        protected virtual Topics.Radical.Model.PropertyMetadata<T> GetDefaultMetadata<T>(string propertyName) { }
+        protected Topics.Radical.Model.PropertyMetadata<T> GetPropertyMetadata<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected Topics.Radical.Model.PropertyMetadata<T> GetPropertyMetadata<T>(string propertyName) { }
+        protected T GetPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected T GetPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, System.Func<T> initialValueSetter) { }
+        protected internal T GetPropertyValue<T>(string propertyName) { }
+        protected virtual bool HasMetadata<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected virtual void OnPropertyChanged(System.ComponentModel.PropertyChangedEventArgs e) { }
+        protected void OnPropertyChanged(string propertyName) { }
+        protected void OnPropertyChanged<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected void ResumeNotificationsFor<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected Topics.Radical.Model.PropertyMetadata<T> SetInitialPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, T value) { }
+        protected Topics.Radical.Model.PropertyMetadata<T> SetInitialPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, System.Func<T> lazyValue) { }
+        protected Topics.Radical.Model.PropertyMetadata<T> SetInitialPropertyValue<T>(string property, T value) { }
+        protected virtual void SetPropertyMetadata<T>(Topics.Radical.Model.PropertyMetadata<T> metadata) { }
+        protected void SetPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, T data) { }
+        protected void SetPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, T data, Topics.Radical.Model.PropertyValueChanged<T> pvc) { }
+        protected void SetPropertyValue<T>(string propertyName, T data) { }
+        protected virtual void SetPropertyValue<T>(string propertyName, T data, Topics.Radical.Model.PropertyValueChanged<T> pvc) { }
+        protected void SetPropertyValueCore<T>(string propertyName, T data, Topics.Radical.Model.PropertyValueChanged<T> pvc) { }
+        protected System.IDisposable SuspendNotificationsOf<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+    }
+    public class EntityCollection<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IComponent, System.ComponentModel.ISite, System.ComponentModel.ISupportInitialize, System.IDisposable, System.IServiceProvider, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable, Topics.Radical.ComponentModel.IEntityCollection<T>
+    
+    {
+        protected static readonly string SerializationKey;
+        public EntityCollection() { }
+        public EntityCollection(int capacity) { }
+        public EntityCollection(System.Collections.Generic.IEnumerable<T> collection) { }
+        public EntityCollection(System.Collections.Generic.IList<T> storage) { }
+        protected EntityCollection(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public virtual bool AllowNew { get; }
+        public int Count { get; }
+        public Topics.Radical.ComponentModel.IEntityView<T> DefaultView { get; }
+        protected System.ComponentModel.EventHandlerList Events { get; }
+        public bool IsInitializing { get; }
+        protected virtual bool IsReadOnly { get; }
+        public T this[int index] { get; set; }
+        public Topics.Radical.Model.EntityCollection<T>.CollectionSettings Settings { get; }
+        protected System.Collections.Generic.IList<T> Storage { get; }
+        public event System.EventHandler<Topics.Radical.ComponentModel.CollectionChangedEventArgs<T>> CollectionChanged;
+        public event System.EventHandler Disposed;
+        public void Add(T item) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<T> list) { }
+        public virtual void BeginInit() { }
+        public void Clear() { }
+        public bool Contains(T item) { }
+        public void CopyTo(T[] array) { }
+        public void CopyTo(T[] array, int arrayIndex) { }
+        public T CreateNew() { }
+        public Topics.Radical.ComponentModel.IEntityView<T> CreateView() { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        public void EndInit() { }
+        public virtual void EndInit(bool notify) { }
+        protected void EnsureNotDisposed() { }
+        protected override void Finalize() { }
+        public virtual System.Collections.Generic.IEnumerator<T> GetEnumerator() { }
+        protected virtual T GetValueAt(int index) { }
+        public int IndexOf(T item) { }
+        public void Insert(int index, T item) { }
+        public void Move(T item, int newIndex) { }
+        public void Move(int oldIndex, int newIndex) { }
+        protected virtual void OnAddCompleted(int index, T value) { }
+        protected virtual void OnAddRange(System.Collections.Generic.IEnumerable<T> rangeToAdd) { }
+        protected virtual void OnAddRangeCompleted(System.Collections.Generic.IEnumerable<T> addedRange) { }
+        protected virtual void OnClearCompleted(System.Collections.Generic.IEnumerable<T> clearedItems) { }
+        protected virtual void OnCollectionChanged(Topics.Radical.ComponentModel.CollectionChangedEventArgs<T> e) { }
+        protected virtual Topics.Radical.ComponentModel.IEntityView<T> OnCreateView() { }
+        protected virtual T OnCreatingNew() { }
+        protected virtual void OnDeserialization(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected virtual void OnDeserializationCompleted(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected virtual void OnDisposed() { }
+        protected virtual void OnGetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected virtual void OnInitialize() { }
+        protected virtual void OnInsert(Topics.Radical.Model.InsertEventArgs<T> e) { }
+        protected virtual void OnInsertCompleted(int index, T value) { }
+        protected virtual void OnMoveCompleted(int oldIndex, int newIndex, T value) { }
+        protected virtual void OnRemoveCompleted(T value, int index) { }
+        protected virtual void OnSetValueAt(Topics.Radical.Model.SetValueAtEventArgs<T> e) { }
+        protected virtual void OnSetValueAtCompleted(int index, T newValue, T overwrittenValue) { }
+        public bool Remove(T item) { }
+        protected bool Remove(T item, bool notify) { }
+        public void RemoveAt(int index) { }
+        protected void RemoveAt(int index, bool notify) { }
+        public void Reverse() { }
+        protected void SetValueAt(int index, T value) { }
+        public T[] ToArray() { }
+        protected virtual void UnwireListItem(T item) { }
+        protected virtual void WireListItem(T item) { }
+        public class CollectionSettings<T>
+        
+        {
+            public CollectionSettings() { }
+            public bool NotifyListItemPropertyChanged { get; set; }
+        }
+    }
+    public class EntityItemView<T> : System.ComponentModel.ICustomTypeDescriptor, System.ComponentModel.IDataErrorInfo, System.ComponentModel.IEditableObject, System.ComponentModel.INotifyPropertyChanged, Topics.Radical.ComponentModel.IEntityItemView, Topics.Radical.ComponentModel.IEntityItemView<T>, Topics.Radical.ComponentModel.INotifyEditableObject
+    
+    {
+        public EntityItemView(Topics.Radical.ComponentModel.IEntityView<T> view, T entityItem) { }
+        public T EntityItem { get; }
+        public virtual string Error { get; }
+        public virtual string this[string columnName] { get; }
+        public Topics.Radical.ComponentModel.IEntityView<T> View { get; }
+        public event System.EventHandler EditBegun;
+        public event System.EventHandler EditCanceled;
+        public event System.EventHandler EditEnded;
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        public void BeginEdit() { }
+        public void CancelEdit() { }
+        public void Delete() { }
+        public void EndEdit() { }
+        public override bool Equals(object obj) { }
+        public TValue GetCustomValue<TValue>(string customPropertyName) { }
+        public override int GetHashCode() { }
+        public void NotifyPropertyChanged(string propertyName) { }
+        protected virtual void OnEditBegun() { }
+        protected virtual void OnEditCanceled() { }
+        protected virtual void OnEditEnded() { }
+        protected virtual void OnInit() { }
+        protected virtual void OnPropertyChanged(System.ComponentModel.PropertyChangedEventArgs args) { }
+        public void SetCustomValue<TValue>(string customPropertyName, TValue value) { }
+    }
+    public abstract class EntityItemViewFilterBase<T> : Topics.Radical.ComponentModel.IEntityItemViewFilter, Topics.Radical.ComponentModel.IEntityItemViewFilter<T>
+    
+    {
+        protected EntityItemViewFilterBase() { }
+        public abstract bool ShouldInclude(T item);
+        public override string ToString() { }
+    }
+    public class EntityItemViewSortComparer<T> : System.Collections.Generic.IComparer<Topics.Radical.ComponentModel.IEntityItemView<T>>
+    
+    {
+        public EntityItemViewSortComparer(System.ComponentModel.ListSortDescriptionCollection sortDescriptions) { }
+        protected System.ComponentModel.ListSortDescriptionCollection SortDescriptions { get; }
+        public int Compare(Topics.Radical.ComponentModel.IEntityItemView<T> x, Topics.Radical.ComponentModel.IEntityItemView<T> y) { }
+        protected virtual int OnCompare(Topics.Radical.ComponentModel.IEntityItemView<T> x, Topics.Radical.ComponentModel.IEntityItemView<T> y) { }
+    }
+    public class EntityView<T> : System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IEntityItemView<T>>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IBindingList, System.ComponentModel.IBindingListView, System.ComponentModel.ICancelAddNew, System.ComponentModel.IComponent, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.IRaiseItemChangedEvents, System.ComponentModel.ISupportInitialize, System.ComponentModel.ITypedList, System.IDisposable, System.IServiceProvider, Topics.Radical.ComponentModel.IEntityView, Topics.Radical.ComponentModel.IEntityView<T>
+    
+    {
+        public EntityView() { }
+        public EntityView(Topics.Radical.ComponentModel.IEntityCollection<T> list) { }
+        public EntityView(T[] list) { }
+        public EntityView(System.Collections.Generic.IList<T> list) { }
+        protected EntityView(System.Collections.IList list) { }
+        public virtual bool AllowEdit { get; set; }
+        public bool AllowMove { get; }
+        public virtual bool AllowNew { get; set; }
+        public virtual bool AllowRemove { get; set; }
+        public virtual bool AllowSort { get; set; }
+        public bool AutoGenerateProperties { get; set; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+        public virtual System.ComponentModel.IContainer Container { get; }
+        public int Count { get; }
+        protected System.Collections.Generic.IDictionary<string, Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T>> CustomProperties { get; }
+        public System.Collections.IList DataSource { get; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+        public virtual bool DesignMode { get; }
+        protected System.ComponentModel.EventHandlerList Events { get; }
+        public Topics.Radical.ComponentModel.IEntityItemViewFilter<T> Filter { get; set; }
+        protected Topics.Radical.Model.Indexer<T> Indexer { get; }
+        public bool IsAddingNew { get; }
+        public bool IsArrayBased { get; }
+        public bool IsDetached { get; }
+        public bool IsFiltered { get; }
+        protected bool IsInitializing { get; }
+        public bool IsSorted { get; }
+        public Topics.Radical.ComponentModel.IEntityItemView<T> this[int index] { get; set; }
+        protected Topics.Radical.ComponentModel.IEntityItemView<T> PendingNewItem { get; }
+        public bool RaisesItemChangedEvents { get; }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
+        public virtual System.ComponentModel.ISite Site { get; set; }
+        public System.ComponentModel.ListSortDescriptionCollection SortDescriptions { get; }
+        public System.ComponentModel.ListSortDirection SortDirection { get; }
+        public System.ComponentModel.PropertyDescriptor SortProperty { get; }
+        public event System.EventHandler<Topics.Radical.Model.AddingNewEventArgs<T>> AddingNew;
+        public event System.EventHandler Disposed;
+        public event System.EventHandler FilterChanged;
+        public event System.ComponentModel.ListChangedEventHandler ListChanged;
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        public event System.EventHandler SortChanged;
+        public void AddIndex(System.ComponentModel.PropertyDescriptor property) { }
+        public void AddIndex(string propertyName) { }
+        public Topics.Radical.ComponentModel.IEntityItemView<T> AddNew(System.Action<Topics.Radical.Model.AddingNewEventArgs<T>> addNewInterceptor) { }
+        public Topics.Radical.ComponentModel.IEntityItemView<T> AddNew() { }
+        public virtual Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> customProperty) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(string propertyName) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping(string propertyName, string displayName) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter, System.Func<TProperty> defaultValueInterceptor) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter, Topics.Radical.ComponentModel.EntityItemViewValueSetter<T, TProperty> setter) { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> AddPropertyMapping<TProperty>(string customPropertyName, Topics.Radical.ComponentModel.EntityItemViewValueGetter<T, TProperty> getter, Topics.Radical.ComponentModel.EntityItemViewValueSetter<T, TProperty> setter, System.Func<TProperty> defaultValueInterceptor) { }
+        public void ApplyFilter(System.Predicate<T> predicate) { }
+        public void ApplySort(System.ComponentModel.PropertyDescriptor property, System.ComponentModel.ListSortDirection direction) { }
+        public void ApplySort(System.ComponentModel.ListSortDescriptionCollection sorts) { }
+        public void ApplySort(string sort) { }
+        public void ApplySort(System.Collections.Generic.IComparer<Topics.Radical.ComponentModel.IEntityItemView<T>> comparer) { }
+        public void CancelNew() { }
+        public void CancelNew(int itemIndex) { }
+        protected internal Topics.Radical.ComponentModel.IEntityItemView<T> CreateEntityItemView(T sourceItem) { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        public void EndNew() { }
+        public void EndNew(int itemIndex) { }
+        protected override void Finalize() { }
+        public int Find(System.ComponentModel.PropertyDescriptor property, object key) { }
+        public int Find(string propertyName, object key) { }
+        public System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T>> GetCustomProperties() { }
+        public Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> GetCustomProperty(string name) { }
+        public TValue GetCustomPropertyValue<TValue>(string customPropertyName, Topics.Radical.ComponentModel.IEntityItemView<T> owner) { }
+        protected virtual TValue GetCustomPropertyValueCore<TValue>(string customPropertyName, Topics.Radical.ComponentModel.IEntityItemView<T> owner) { }
+        public System.ComponentModel.PropertyDescriptor GetProperty(string name) { }
+        public virtual object GetService(System.Type serviceType) { }
+        public int IndexOf(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public int IndexOf(T item) { }
+        protected bool IsInAddingNewQueue(T item) { }
+        public bool IsPropertyMappingDefined(string propertyName) { }
+        public void Move(int sourceIndex, int newIndex) { }
+        public void Move(Topics.Radical.ComponentModel.IEntityItemView<T> item, int newIndex) { }
+        protected virtual void OnAddingNew(Topics.Radical.Model.AddingNewEventArgs<T> e) { }
+        protected virtual void OnCancelNew(int itemIndex) { }
+        protected virtual void OnCollectionChanged(Topics.Radical.Model.RebuildIndexesEventArgs e, Topics.Radical.ComponentModel.CollectionChangeType changeType) { }
+        protected virtual Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> OnCreateDescriptor(System.Reflection.PropertyInfo property) { }
+        protected virtual System.Collections.Generic.IComparer<Topics.Radical.ComponentModel.IEntityItemView<T>> OnCreateSortComparer() { }
+        protected virtual void OnEndNew(int index) { }
+        protected virtual void OnEndNewCompleted(Topics.Radical.Model.RebuildIndexesEventArgs e) { }
+        protected virtual void OnEntityItemViewEditBegun(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        protected virtual void OnEntityItemViewEditCanceled(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        protected virtual void OnEntityItemViewEditEnded(Topics.Radical.Model.RebuildIndexesEventArgs e) { }
+        protected virtual void OnFilterChanged() { }
+        protected virtual System.ComponentModel.PropertyDescriptorCollection OnGetItemProperties(System.ComponentModel.PropertyDescriptor[] listAccessors) { }
+        protected virtual string OnGetListName(System.ComponentModel.PropertyDescriptor[] listAccessors) { }
+        protected virtual void OnInit() { }
+        protected virtual void OnListChanged(System.ComponentModel.ListChangedEventArgs e) { }
+        protected virtual void OnLoad() { }
+        protected void OnPropertyChanged<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        protected virtual void OnPropertyChanged(string propertyName) { }
+        protected virtual void OnRemovedAt(Topics.Radical.Model.RebuildIndexesEventArgs e) { }
+        protected virtual void OnSortChanged() { }
+        protected internal void OnUnwireEntityItemView(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        protected internal void OnWireEntityItemView(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public virtual void Refresh() { }
+        public void RemoveFilter() { }
+        public void RemoveIndex(System.ComponentModel.PropertyDescriptor property) { }
+        public void RemoveIndex(string propertyName) { }
+        public virtual bool RemovePropertyMapping(Topics.Radical.ComponentModel.EntityItemViewPropertyDescriptor<T> customProperty) { }
+        public bool RemovePropertyMapping(string propertyName) { }
+        public void RemoveSort() { }
+        public void SetCustomPropertyValue<TValue>(string customPropertyName, Topics.Radical.ComponentModel.IEntityItemView<T> owner, TValue value) { }
+    }
+    public sealed class Indexer<T> : System.Collections.Generic.ICollection<Topics.Radical.ComponentModel.IEntityItemView<T>>, System.Collections.Generic.IEnumerable<Topics.Radical.ComponentModel.IEntityItemView<T>>, System.Collections.IEnumerable
+    
+    {
+        public int Count { get; }
+        public bool IsReadOnly { get; }
+        public Topics.Radical.ComponentModel.IEntityItemView<T> this[int index] { get; }
+        public void Add(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public void AddIndex(System.ComponentModel.PropertyDescriptor property) { }
+        public void ApplySort() { }
+        public void Clear() { }
+        public void ClearIndexes() { }
+        public bool Contains(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public bool Contains(T item) { }
+        public void CopyTo(Topics.Radical.ComponentModel.IEntityItemView<>[] array, int arrayIndex) { }
+        public int Find(System.ComponentModel.PropertyDescriptor property, object key) { }
+        public int FindEntityItemViewIndexInView(int entityIndexInDataSource) { }
+        public int FindObjectIndexInDataSource(int objectItemViewIndexInView) { }
+        public int IndexOf(T item) { }
+        public int IndexOf(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public void Rebuild() { }
+        public bool Remove(Topics.Radical.ComponentModel.IEntityItemView<T> item) { }
+        public void RemoveAt(int index) { }
+        public void RemoveIndex(System.ComponentModel.PropertyDescriptor property) { }
+        public void RemoveSort() { }
+    }
+    public class InsertEventArgs<T> : System.ComponentModel.CancelEventArgs
+    
+    {
+        public InsertEventArgs(int index, T newValue) { }
+        public int Index { get; }
+        public T NewValue { get; }
+    }
+    public abstract class MementoEntity : Topics.Radical.Model.Entity, Topics.Radical.ComponentModel.ChangeTracking.IMemento
+    {
+        protected MementoEntity() { }
+        protected MementoEntity(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService memento) { }
+        protected MementoEntity(bool registerAsTransient) { }
+        protected MementoEntity(Topics.Radical.ComponentModel.ChangeTracking.ChangeTrackingRegistration registration) { }
+        protected MementoEntity(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService memento, Topics.Radical.ComponentModel.ChangeTracking.ChangeTrackingRegistration registration) { }
+        protected MementoEntity(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService memento, bool registerAsTransient) { }
+        protected virtual bool IsTracking { get; }
+        protected Topics.Radical.ComponentModel.ChangeTracking.IChange CacheChange<T>(string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restore) { }
+        protected Topics.Radical.ComponentModel.ChangeTracking.IChange CacheChange<T>(string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restore, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> commit) { }
+        protected Topics.Radical.ComponentModel.ChangeTracking.IChange CacheChange<T>(string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> restore, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> commit, Topics.Radical.ComponentModel.ChangeTracking.AddChangeBehavior direction) { }
+        protected virtual Topics.Radical.ComponentModel.ChangeTracking.IChange CacheChangeOnRejectCallback<T>(string propertyName, T value, Topics.Radical.ComponentModel.ChangeTracking.RejectCallback<T> rejectCallback, Topics.Radical.ComponentModel.ChangeTracking.CommitCallback<T> commitCallback, Topics.Radical.ComponentModel.ChangeTracking.ChangeRejectedEventArgs<T> args) { }
+        protected override void Dispose(bool disposing) { }
+        protected override void EnsureNotDisposed() { }
+        protected override Topics.Radical.Model.PropertyMetadata<T> GetDefaultMetadata<T>(string propertyName) { }
+        protected Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService GetTrackingService() { }
+        protected virtual void OnMementoChanged(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService newMemento, Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService oldMemento) { }
+        protected virtual void OnRegisterTransient(Topics.Radical.ComponentModel.ChangeTracking.TransientRegistration transientRegistration) { }
+        protected void RegisterTransient() { }
+        protected Topics.Radical.Model.MementoPropertyMetadata<T> SetInitialPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, T value, bool trackChanges) { }
+        protected Topics.Radical.Model.MementoPropertyMetadata<T> SetInitialPropertyValue<T>(System.Linq.Expressions.Expression<System.Func<T>> property, System.Func<T> lazyValue, bool trackChanges) { }
+        protected Topics.Radical.Model.MementoPropertyMetadata<T> SetInitialPropertyValue<T>(string property, T value, bool trackChanges) { }
+        protected override void SetPropertyValue<T>(string propertyName, T data, Topics.Radical.Model.PropertyValueChanged<T> pvc) { }
+    }
+    public class MementoEntityCollection<T> : Topics.Radical.Model.EntityCollection<T>, Topics.Radical.ComponentModel.ChangeTracking.IMemento
+    
+    {
+        public MementoEntityCollection() { }
+        public MementoEntityCollection(int capacity) { }
+        public MementoEntityCollection(System.Collections.Generic.IEnumerable<T> collection) { }
+        public MementoEntityCollection(System.Collections.Generic.IList<T> storage) { }
+        protected MementoEntityCollection(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected bool IsCachingSuspended { get; }
+        protected virtual bool IsTracking { get; }
+        public Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Memento { get; set; }
+        public override void BeginInit() { }
+        public override void EndInit(bool notify) { }
+        protected override void OnAddCompleted(int index, T value) { }
+        protected override void OnAddRangeCompleted(System.Collections.Generic.IEnumerable<T> addedRange) { }
+        protected override void OnClearCompleted(System.Collections.Generic.IEnumerable<T> clearedItems) { }
+        protected override void OnDeserialization(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected override void OnDeserializationCompleted(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected override void OnInitialize() { }
+        protected override void OnInsertCompleted(int index, T value) { }
+        protected virtual void OnMementoChanged(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService newMemento, Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService oldMemento) { }
+        protected override void OnMoveCompleted(int oldIndex, int newIndex, T value) { }
+        protected override void OnRemoveCompleted(T value, int index) { }
+        protected override void OnSetValueAtCompleted(int index, T newValue, T overwrittenValue) { }
+        protected void ResumeCaching() { }
+        protected void SuspendCaching() { }
+        protected override void WireListItem(T item) { }
+    }
+    public class static MementoPropertyMetadata
+    {
+        public static Topics.Radical.Model.MementoPropertyMetadata<T> Create<T>(object propertyOwner, System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public static Topics.Radical.Model.MementoPropertyMetadata<T> Create<T>(object propertyOwner, string propertyName) { }
+    }
+    public class MementoPropertyMetadata<T> : Topics.Radical.Model.PropertyMetadata<T>, Topics.Radical.ComponentModel.ChangeTracking.IMementoPropertyMetadata
+    
+    {
+        public MementoPropertyMetadata(object propertyOwner, string propertyName) { }
+        public MementoPropertyMetadata(object propertyOwner, System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public bool TrackChanges { get; set; }
+        public Topics.Radical.Model.MementoPropertyMetadata<T> DisableChangesTracking() { }
+        public Topics.Radical.Model.MementoPropertyMetadata<T> EnableChangesTracking() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property | System.AttributeTargets.All)]
+    public class MementoPropertyMetadataAttribute : Topics.Radical.Model.PropertyMetadataAttribute
+    {
+        public MementoPropertyMetadataAttribute() { }
+        public bool TrackChanges { get; set; }
+    }
+    public sealed class NullDataContext : System.IDisposable, Topics.Radical.ComponentModel.IDataContext
+    {
+        public static readonly Topics.Radical.ComponentModel.IDataContext Instance;
+        public bool HasPendingChanges { get; }
+        public Topics.Radical.ComponentModel.ITransaction Transaction { get; }
+        public Topics.Radical.ComponentModel.ITransaction BeginTransaction() { }
+        public Topics.Radical.ComponentModel.ITransaction BeginTransaction(System.Data.IsolationLevel isolationLevel) { }
+        public void Clear() { }
+        public void Delete(object entity) { }
+        public void Detach(object entity) { }
+        public void Dispose() { }
+        public int Execute<TCommand>(TCommand command)
+            where TCommand : Topics.Radical.ComponentModel.QueryModel.IBatchCommand { }
+        public void FlushChanges() { }
+        public T GetByKey<T>(object key) { }
+        public System.Collections.Generic.IList<TResult> GetByQuery<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec) { }
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(Topics.Radical.Model.NullDataContext.<GetBySpecification>d__18<, >))]
+        public System.Collections.Generic.IEnumerable<TResult> GetBySpecification<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult> specification) { }
+        public TResult GetScalar<TSource, TResult>(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec) { }
+        public void Insert(object entity) { }
+        public bool IsAttached(object entity) { }
+        public void Save(object entity) { }
+        public void Update(object entity) { }
+    }
+    public sealed class PredicateEntityItemViewFilter<T> : Topics.Radical.Model.EntityItemViewFilterBase<T>
+    
+    {
+        public PredicateEntityItemViewFilter(System.Predicate<T> filterDelegate) { }
+        public PredicateEntityItemViewFilter(System.Predicate<T> filterDelegate, string filterName) { }
+        public System.Predicate<T> FilterDelegate { get; }
+        public override bool ShouldInclude(T item) { }
+        public override string ToString() { }
+    }
+    public abstract class PropertyMetadata : System.IDisposable
+    {
+        protected PropertyMetadata(object propertyOwner, string propertyName) { }
+        public bool NotifyChanges { get; set; }
+        protected System.Reflection.PropertyInfo Property { get; }
+        public string PropertyName { get; }
+        public Topics.Radical.Model.PropertyMetadata AddCascadeChangeNotifications<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public Topics.Radical.Model.PropertyMetadata AddCascadeChangeNotifications(string property) { }
+        public static Topics.Radical.Model.PropertyMetadata<T> Create<T>(object propertyOwner, System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public static Topics.Radical.Model.PropertyMetadata<T> Create<T>(object propertyOwner, string propertyName) { }
+        public Topics.Radical.Model.PropertyMetadata DisableChangesNotifications() { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Dispose() { }
+        public Topics.Radical.Model.PropertyMetadata EnableChangesNotifications() { }
+        protected override void Finalize() { }
+        public System.Collections.Generic.IEnumerable<string> GetCascadeChangeNotifications() { }
+        public abstract Topics.Radical.Model.PropertyValue GetDefaultValue();
+        public Topics.Radical.Model.PropertyMetadata RemoveCascadeChangeNotifications<T>(System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public Topics.Radical.Model.PropertyMetadata RemoveCascadeChangeNotifications(string property) { }
+        public abstract void SetDefaultValue(Topics.Radical.Model.PropertyValue value);
+    }
+    public class PropertyMetadata<T> : Topics.Radical.Model.PropertyMetadata
+    
+    {
+        public PropertyMetadata(object propertyOwner, string propertyName) { }
+        public PropertyMetadata(object propertyOwner, System.Linq.Expressions.Expression<System.Func<T>> property) { }
+        public virtual T DefaultValue { get; set; }
+        public System.Func<T> DefaultValueInterceptor { get; set; }
+        protected override void Dispose(bool disposing) { }
+        public override Topics.Radical.Model.PropertyValue GetDefaultValue() { }
+        public Topics.Radical.Model.PropertyMetadata<T> OnChanged(System.Action<Topics.Radical.Model.PropertyValueChangedArgs<T>> propertyChangedHandler) { }
+        public override void SetDefaultValue(Topics.Radical.Model.PropertyValue value) { }
+        public Topics.Radical.Model.PropertyMetadata<T> WithDefaultValue(T defaultValue) { }
+        public Topics.Radical.Model.PropertyMetadata<T> WithDefaultValue(System.Func<T> defaultValueInterceptor) { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property | System.AttributeTargets.All)]
+    public class PropertyMetadataAttribute : System.Attribute
+    {
+        public PropertyMetadataAttribute() { }
+    }
+    public abstract class PropertyValue
+    {
+        protected PropertyValue() { }
+        public abstract object GetValue();
+    }
+    public class PropertyValue<T> : Topics.Radical.Model.PropertyValue
+    
+    {
+        public PropertyValue(T value) { }
+        public T Value { get; }
+        public override object GetValue() { }
+    }
+    public delegate void PropertyValueChanged<T>(Topics.Radical.Model.PropertyValueChangedArgs<T> e);
+    public class PropertyValueChangedArgs<T>
+    
+    {
+        public PropertyValueChangedArgs(T newValue, T oldValue) { }
+        public T NewValue { get; }
+        public T OldValue { get; }
+    }
+    public class RebuildIndexesEventArgs : System.ComponentModel.CancelEventArgs
+    {
+        public RebuildIndexesEventArgs(int index) { }
+        public int Index { get; }
+    }
+    public class SetValueAtEventArgs<T> : Topics.Radical.Model.InsertEventArgs<T>
+    
+    {
+        public SetValueAtEventArgs(int index, T newValue, T oldValue) { }
+        public T OldValue { get; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property | System.AttributeTargets.All)]
+    public sealed class SkipPropertyValidationAttribute : System.Attribute
+    {
+        public SkipPropertyValidationAttribute() { }
+    }
+    public sealed class ViewAllEntityItemViewFilter<T> : Topics.Radical.Model.EntityItemViewFilterBase<T>
+    
+    {
+        public static Topics.Radical.ComponentModel.IEntityItemViewFilter Instance { get; }
+        public override bool ShouldInclude(T item) { }
+        public override string ToString() { }
+    }
+}
+namespace Topics.Radical.Model.Factories
+{
+    
+    public class ChangeTrackingServiceFactory : Topics.Radical.ComponentModel.Factories.IChangeTrackingServiceFactory
+    {
+        public ChangeTrackingServiceFactory(System.IServiceProvider container) { }
+        public Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService Create() { }
+    }
+}
+namespace Topics.Radical.Model.Providers
+{
+    
+    public class QuerySystemManager : Topics.Radical.ComponentModel.QueryModel.IQuerySystemManager
+    {
+        public QuerySystemManager(System.IServiceProvider container) { }
+        public Topics.Radical.ComponentModel.QueryModel.IBatchCommandEngine<TCommand, TProvider> GetBatchCommandEngine<TCommand, TProvider>(TCommand command)
+            where TCommand : Topics.Radical.ComponentModel.QueryModel.IBatchCommand { }
+        public Topics.Radical.ComponentModel.QueryModel.IQueryEngine<TSource, TResult, TProvider> GetQueryEngine<TSource, TResult, TProvider>(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec) { }
+        public Topics.Radical.ComponentModel.QueryModel.IScalarEvaluator<TSource, TResult, TProvider> GetScalarEvaluator<TSource, TResult, TProvider>(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec) { }
+    }
+}
+namespace Topics.Radical.Model.QueryModel
+{
+    
+    public abstract class AbstractQueryEngine<TQuery, TSource, TResult, TProvider> : Topics.Radical.ComponentModel.QueryModel.IQueryEngine<TSource, TResult, TProvider>, Topics.Radical.ComponentModel.QueryModel.IQueryEngine<TQuery, TSource, TResult, TProvider>
+        where TQuery : Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<, >
+    
+    
+    
+    {
+        protected AbstractQueryEngine() { }
+        public abstract System.Collections.Generic.IList<TResult> ExecuteQuery(TQuery querySpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+        public System.Collections.Generic.IList<TResult> ExecuteQuery(Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult> querySpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider) { }
+    }
+    public abstract class AbstractQuerySpecification<TSource, TResult> : Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult>, Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult>
+    
+    
+    {
+        protected AbstractQuerySpecification() { }
+    }
+    public abstract class AbstractScalarEvaluator<TScalar, TSource, TResult, TProvider> : Topics.Radical.ComponentModel.QueryModel.IScalarEvaluator<TSource, TResult, TProvider>, Topics.Radical.ComponentModel.QueryModel.IScalarEvaluator<TScalar, TSource, TResult, TProvider>
+        where TScalar : Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<, >
+    
+    
+    
+    {
+        protected AbstractScalarEvaluator() { }
+        public abstract TResult Evaluate(TScalar scalarSpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider);
+        public TResult Evaluate(Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult> scalarSpec, Topics.Radical.ComponentModel.IDataContext context, TProvider provider) { }
+    }
+    public abstract class AbstractScalarSpecification<TSource, TResult> : Topics.Radical.ComponentModel.QueryModel.IScalarSpecification<TSource, TResult>, Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult>
+    
+    
+    {
+        protected AbstractScalarSpecification() { }
+    }
+    public class AllEntitiesQuery<TSource, TResult> : Topics.Radical.ComponentModel.QueryModel.IQuerySpecification<TSource, TResult>, Topics.Radical.ComponentModel.QueryModel.ISpecification<TSource, TResult>
+    
+    
+    {
+        public AllEntitiesQuery() { }
+    }
+    public class EntitiesByKeywordsQuery<TSource, TResult> : Topics.Radical.Model.QueryModel.AbstractQuerySpecification<TSource, TResult>
+    
+    
+    {
+        public EntitiesByKeywordsQuery(System.Collections.Generic.IEnumerable<string> keywords) { }
+        public System.Collections.Generic.IEnumerable<string> Keywords { get; }
+        public override string ToString() { }
+    }
+    public class EntityByKeyQuery<TSource, TResult> : Topics.Radical.Model.QueryModel.AbstractScalarSpecification<TSource, TResult>
+    
+    
+    {
+        public EntityByKeyQuery(Topics.Radical.ComponentModel.IKey key) { }
+        public Topics.Radical.ComponentModel.IKey Key { get; }
+        public override string ToString() { }
+    }
+}
+namespace Topics.Radical.Model.Services
+{
+    
+    public class Int32KeyService : Topics.Radical.ComponentModel.IKeyService
+    {
+        public Int32KeyService() { }
+        public Topics.Radical.ComponentModel.IKey GenerateEmpty() { }
+    }
+    public class static KeyServiceProxy
+    {
+        public static Topics.Radical.ComponentModel.IKeyService CurrentService { get; set; }
+    }
+}
+namespace Topics.Radical.Observers
+{
+    
+    public abstract class AbstractMonitor : Topics.Radical.ComponentModel.IMonitor
+    {
+        protected AbstractMonitor() { }
+        protected AbstractMonitor(Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        protected AbstractMonitor(object source) { }
+        protected AbstractMonitor(object source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        protected Topics.Radical.ComponentModel.IDispatcher Dispatcher { get; }
+        protected System.WeakReference WeakSource { get; }
+        public event System.EventHandler Changed;
+        public void NotifyChanged() { }
+        protected virtual void OnChanged() { }
+        protected abstract void OnStopMonitoring(bool targetDisposed);
+        protected virtual void StartMonitoring(object source) { }
+        public void StopMonitoring() { }
+    }
+    public abstract class AbstractMonitor<T> : Topics.Radical.Observers.AbstractMonitor, Topics.Radical.ComponentModel.IMonitor, Topics.Radical.ComponentModel.IMonitor<T>
+    
+    {
+        protected AbstractMonitor(T source) { }
+        protected AbstractMonitor(T source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        protected AbstractMonitor() { }
+        protected AbstractMonitor(Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        public T Source { get; }
+    }
+    public class static BrokerObserver
+    {
+        public static Topics.Radical.Observers.MessageBrokerMonitor Using(Topics.Radical.ComponentModel.Messaging.IMessageBroker broker) { }
+    }
+    public class EntityViewListChangedMonitor : Topics.Radical.Observers.AbstractMonitor<Topics.Radical.ComponentModel.IEntityView>
+    {
+        public EntityViewListChangedMonitor(Topics.Radical.ComponentModel.IEntityView source) { }
+        public EntityViewListChangedMonitor() { }
+        public EntityViewListChangedMonitor(Topics.Radical.ComponentModel.IEntityView source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        public EntityViewListChangedMonitor(Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        public void Observe(Topics.Radical.ComponentModel.IEntityView source) { }
+        protected override void OnStopMonitoring(bool targetDisposed) { }
+        protected override void StartMonitoring(object source) { }
+    }
+    public class MementoMonitor : Topics.Radical.Observers.AbstractMonitor<Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService>
+    {
+        public MementoMonitor(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService source) { }
+        public MementoMonitor(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        protected override void OnStopMonitoring(bool targetDisposed) { }
+    }
+    public class static MementoObserver
+    {
+        public static Topics.Radical.Observers.MementoMonitor Monitor(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService source) { }
+        public static Topics.Radical.Observers.MementoMonitor Monitor(Topics.Radical.ComponentModel.ChangeTracking.IChangeTrackingService source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+    }
+    public class MessageBrokerMonitor : Topics.Radical.Observers.AbstractMonitor<Topics.Radical.ComponentModel.Messaging.IMessageBroker>
+    {
+        public MessageBrokerMonitor(Topics.Radical.ComponentModel.Messaging.IMessageBroker broker) { }
+        protected override void OnStopMonitoring(bool targetDisposed) { }
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitFor<TMessage>()
+            where TMessage :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitFor<TMessage>(Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel)
+            where TMessage :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitFor<TMessage>(System.Func<TMessage, bool> filter)
+            where TMessage :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        [System.ObsoleteAttribute("Use the POCO overload not constrained to the IMessage interface", false)]
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitFor<TMessage>(System.Func<TMessage, bool> filter, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel)
+            where TMessage :  class, Topics.Radical.ComponentModel.Messaging.IMessage { }
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitingFor<TMessage>()
+            where TMessage :  class { }
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitingFor<TMessage>(Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel)
+            where TMessage :  class { }
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitingFor<TMessage>(System.Func<TMessage, bool> filter)
+            where TMessage :  class { }
+        public Topics.Radical.Observers.MessageBrokerMonitor WaitingFor<TMessage>(System.Func<TMessage, bool> filter, Topics.Radical.ComponentModel.Messaging.InvocationModel invocationModel)
+            where TMessage :  class { }
+    }
+    public class PropertyChangedMonitor : Topics.Radical.Observers.AbstractMonitor
+    {
+        public PropertyChangedMonitor(System.ComponentModel.INotifyPropertyChanged source) { }
+        protected override void OnStopMonitoring(bool targetDisposed) { }
+        protected override void StartMonitoring(object source) { }
+    }
+    public class PropertyChangedMonitor<T> : Topics.Radical.Observers.AbstractMonitor<T>, System.ComponentModel.INotifyPropertyChanged
+        where T : System.ComponentModel.INotifyPropertyChanged
+    {
+        public PropertyChangedMonitor(T source) { }
+        public PropertyChangedMonitor(T source, Topics.Radical.ComponentModel.IDispatcher dispatcher) { }
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> Observe(string property) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> Observe<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> property) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> Observe<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> property, System.Action<T, string> callback) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> Observe(string propertyName, System.Action<T, string> callback) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> Observe<TValue>(Topics.Radical.Observable<TValue> property) { }
+        protected virtual void OnPropertyChanged(System.ComponentModel.PropertyChangedEventArgs args) { }
+        protected override void OnStopMonitoring(bool targetDisposed) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> StopObserving<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> property) { }
+        public Topics.Radical.Observers.PropertyChangedMonitor<T> StopObserving<TValue>(Topics.Radical.Observable<TValue> property) { }
+    }
+    public class static PropertyObserver
+    {
+        public static Topics.Radical.Observers.PropertyChangedMonitor<T> For<T>(T source)
+            where T : System.ComponentModel.INotifyPropertyChanged { }
+        public static Topics.Radical.Observers.PropertyChangedMonitor<T> For<T>(T source, Topics.Radical.ComponentModel.IDispatcher dispatcher)
+            where T : System.ComponentModel.INotifyPropertyChanged { }
+        public static Topics.Radical.Observers.PropertyChangedMonitor ForAllPropertiesOf<T>(T source)
+            where T : System.ComponentModel.INotifyPropertyChanged { }
+    }
+}
+namespace Topics.Radical.Reflection
+{
+    
+    public class static AssemblyExtensions
+    {
+        public static T GetAttribute<T>(this System.Reflection.Assembly assembly)
+            where T : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<T> GetAttributes<T>(this System.Reflection.Assembly assembly)
+            where T : System.Attribute { }
+        public static bool IsAttributeDefined<T>(this System.Reflection.Assembly assembly)
+            where T : System.Attribute { }
+        public static bool TryGetAttribute<T>(this System.Reflection.Assembly assembly, out T attribute)
+            where T : System.Attribute { }
+    }
+    public delegate object Function();
+    public class static GetAssembly
+    {
+        public static System.Reflection.Assembly ThatContains<T>() { }
+    }
+    public delegate object LateBoundMethod(object target, object[] arguments);
+    public delegate void LateBoundVoidMethod(object target, object[] arguments);
+    public class static MemberInfoExtensions
+    {
+        public static T GetAttribute<T>(this System.Reflection.MemberInfo memberInfo)
+            where T : System.Attribute { }
+        public static T GetAttribute<T>(this System.Reflection.MemberInfo memberInfo, bool inherit)
+            where T : System.Attribute { }
+        public static T[] GetAttributes<T>(this System.Reflection.MemberInfo memberInfo)
+            where T : System.Attribute { }
+        public static T[] GetAttributes<T>(this System.Reflection.MemberInfo memberInfo, bool inherit)
+            where T : System.Attribute { }
+        public static bool IsAttributeDefined<T>(this System.Reflection.MemberInfo memberInfo)
+            where T : System.Attribute { }
+        public static bool IsAttributeDefined<T>(this System.Reflection.MemberInfo memberInfo, bool inherit)
+            where T : System.Attribute { }
+        public static bool TryGetAttribute<T>(this System.Reflection.MemberInfo memberInfo, out T attribute)
+            where T : System.Attribute { }
+    }
+    public class static MethodInfoExtensions
+    {
+        public static Topics.Radical.Reflection.LateBoundMethod CreateDelegate(this System.Reflection.MethodInfo method) { }
+        public static Topics.Radical.Reflection.LateBoundVoidMethod CreateVoidDelegate(this System.Reflection.MethodInfo method) { }
+    }
+    public class static ObjectExtensions
+    {
+        public static System.Func<T> CreateFastPropertyGetter<T>(this object target, string propertyName) { }
+        public static System.Func<T> CreateFastPropertyGetter<T>(this object target, System.Reflection.PropertyInfo property) { }
+        public static Topics.Radical.Reflection.Function CreateFastPropertyGetter(this object target, System.Reflection.PropertyInfo property) { }
+    }
+    public class static ParameterInfoExtension
+    {
+        public static T GetAttribute<T>(this System.Reflection.ParameterInfo memberInfo)
+            where T : System.Attribute { }
+        public static T[] GetAttributes<T>(this System.Reflection.ParameterInfo memberInfo)
+            where T : System.Attribute { }
+        public static bool IsAttributeDefined<T>(this System.Reflection.ParameterInfo memberInfo)
+            where T : System.Attribute { }
+    }
+    public class static TypeExtensions
+    {
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(Topics.Radical.Reflection.TypeExtensions.<GetDescendants>d__7))]
+        public static System.Collections.Generic.IEnumerable<System.Type> GetDescendants(System.Type type) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> GetInheritanceChain(this System.Type type) { }
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(Topics.Radical.Reflection.TypeExtensions.<GetInheritanceChain>d__6))]
+        public static System.Collections.Generic.IEnumerable<System.Type> GetInheritanceChain(this System.Type type, System.Func<System.Type, bool> breakIf) { }
+        public static bool Is<T>(this System.Type type) { }
+        public static bool Is(this System.Type type, System.Type otherType) { }
+        public static string ToShortNameString(this System.Type type) { }
+        public static string ToShortString(this System.Type type) { }
+        public static string ToString(this System.Type type, string format) { }
+    }
+}
+namespace Topics.Radical.Threading
+{
+    
+    public class AsyncErrorEventArgs : System.EventArgs
+    {
+        public AsyncErrorEventArgs(System.Exception error) { }
+        public System.Exception Error { get; }
+        public bool Handled { get; set; }
+    }
+    [System.ObsoleteAttribute("Use the Task Parallel Library (TPL) or the new async/await keywords of C# 5.0.", false)]
+    public class static AsyncWorker
+    {
+        public static Topics.Radical.Threading.IOuputWorker<TResult> Expecting<TResult>() { }
+        public static Topics.Radical.Threading.IOuputWorker<TResult> Expecting<TResult>(TResult sample) { }
+        public static Topics.Radical.Threading.IInputWorker<T> Using<T>(T argument) { }
+    }
+    public interface IAfterArgs<T> : Topics.Radical.Threading.IAsyncArgs<T> { }
+    public interface IAfterArgs<T, TResult> : Topics.Radical.Threading.IAfterArgs<T>, Topics.Radical.Threading.IAsyncArgs<T>
+    
+    
+    {
+        TResult Result { get; }
+    }
+    public interface IAsyncArgs<T>
+    
+    {
+        T Argument { get; }
+        bool IsCancellationPending { get; }
+    }
+    public interface IAsyncArgs<T, TResult> : Topics.Radical.Threading.IAsyncArgs<T>
+    
+    
+    {
+        TResult Result { get; set; }
+    }
+    public interface IAsyncErrorArgs
+    {
+        System.Exception Error { get; }
+        bool Handled { get; set; }
+    }
+    public interface IBeforeArgs<T> : Topics.Radical.Threading.ICancelArgs
+    
+    {
+        T Argument { get; }
+    }
+    public interface ICancelArgs
+    {
+        bool Cancel { get; set; }
+    }
+    public interface IConfiguredInputOutputWorker<T, TResult>
+    
+    
+    {
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IAsyncArgs<T, TResult>> asyncAction);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IAsyncArgs<T, TResult>> asyncAction);
+    }
+    public interface IConfiguredInputWorker<T>
+    
+    {
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IAsyncArgs<T>> asyncHandler);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IAsyncArgs<T>> asyncHandler);
+    }
+    public interface IConfiguredOuputWorker<TResult>
+    
+    {
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IOutputAsyncArgs<TResult>> asyncHandler);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IOutputAsyncArgs<TResult>> asyncHandler);
+    }
+    public interface IExecutableWorker : Topics.Radical.Threading.IWorkerStatus
+    {
+        Topics.Radical.Threading.IExecutableWorker AddTrigger(Topics.Radical.ComponentModel.IMonitor trigger);
+        Topics.Radical.Threading.IWorker Execute();
+    }
+    public interface IInputOutputWorker<T, TResult>
+    
+    
+    {
+        Topics.Radical.Threading.IConfiguredInputOutputWorker<T, TResult> Configure(System.Action<Topics.Radical.Threading.IInputOutputWorkerConfiguration<T, TResult>> cfg);
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IAsyncArgs<T, TResult>> asyncAction);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IAsyncArgs<T, TResult>> asyncAction);
+    }
+    public interface IInputOutputWorkerConfiguration<T, TResult> : Topics.Radical.Threading.IWorkerConfiguration
+    
+    
+    {
+        System.Action<Topics.Radical.Threading.IAfterArgs<T, TResult>> After { get; set; }
+        System.Action<Topics.Radical.Threading.IBeforeArgs<T>> Before { get; set; }
+    }
+    public interface IInputWorker<T>
+    
+    {
+        Topics.Radical.Threading.IInputOutputWorker<T, TResult> AndExpecting<TResult>();
+        Topics.Radical.Threading.IInputOutputWorker<T, TResult> AndExpecting<TResult>(TResult sample);
+        Topics.Radical.Threading.IConfiguredInputWorker<T> Configure(System.Action<Topics.Radical.Threading.IInputWorkerConfiguration<T>> cfg);
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IAsyncArgs<T>> asyncHandler);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IAsyncArgs<T>> asyncHandler);
+    }
+    public interface IInputWorkerConfiguration<T> : Topics.Radical.Threading.IWorkerConfiguration
+    
+    {
+        System.Action<Topics.Radical.Threading.IAfterArgs<T>> After { get; set; }
+        System.Action<Topics.Radical.Threading.IBeforeArgs<T>> Before { get; set; }
+    }
+    public interface IOuputWorker<TResult>
+    
+    {
+        Topics.Radical.Threading.IConfiguredOuputWorker<TResult> Configure(System.Action<Topics.Radical.Threading.IOutputWorkerConfiguration<TResult>> cfg);
+        Topics.Radical.Threading.IWorker Execute(System.Action<Topics.Radical.Threading.IOutputAsyncArgs<TResult>> asyncHandler);
+        Topics.Radical.Threading.IExecutableWorker OnExecute(System.Action<Topics.Radical.Threading.IOutputAsyncArgs<TResult>> asyncHandler);
+    }
+    public interface IOutputAfterArgs<TResult>
+    
+    {
+        TResult Result { get; }
+    }
+    public interface IOutputAsyncArgs<TResult>
+    
+    {
+        TResult Result { get; set; }
+    }
+    public interface IOutputWorkerConfiguration<TResult> : Topics.Radical.Threading.IWorkerConfiguration
+    
+    {
+        System.Action<Topics.Radical.Threading.IOutputAfterArgs<TResult>> After { get; set; }
+        System.Action<Topics.Radical.Threading.ICancelArgs> Before { get; set; }
+    }
+    public interface IWorker : Topics.Radical.Threading.IWorkerStatus
+    {
+        void Cancel();
+    }
+    public interface IWorkerConfiguration
+    {
+        System.Action<Topics.Radical.Threading.IAsyncErrorArgs> Error { get; set; }
+        Topics.Radical.Threading.WarningThreshold WarningThreshold { get; set; }
+    }
+    public interface IWorkerStatus
+    {
+        System.Threading.WaitHandle AsyncWaitHandle { get; }
+        bool HasCompleted { get; }
+        bool IsBusy { get; }
+        public event System.EventHandler<Topics.Radical.Threading.AsyncErrorEventArgs> AsyncError;
+        public event System.EventHandler<Topics.Radical.Threading.WorkCompletedEventArgs> Completed;
+    }
+    public class LimitedConcurrencyLevelTaskScheduler : System.Threading.Tasks.TaskScheduler
+    {
+        public LimitedConcurrencyLevelTaskScheduler(int maxDegreeOfParallelism) { }
+        public virtual int MaximumConcurrencyLevel { get; }
+        protected virtual System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task> GetScheduledTasks() { }
+        protected virtual void QueueTask(System.Threading.Tasks.Task task) { }
+        protected virtual bool TryDequeue(System.Threading.Tasks.Task task) { }
+        protected virtual bool TryExecuteTaskInline(System.Threading.Tasks.Task task, bool taskWasPreviouslyQueued) { }
+    }
+    public sealed class NullDispatcher : Topics.Radical.ComponentModel.IDispatcher
+    {
+        public NullDispatcher() { }
+        public bool IsSafe { get; }
+        public void Dispatch(System.Action action) { }
+        public void Dispatch<T>(T arg, System.Action<T> action) { }
+        public void Dispatch<T1, T2>(T1 arg1, T2 arg2, System.Action<T1, T2> action) { }
+        public TResult Dispatch<TResult>(System.Func<TResult> func) { }
+        public void Invoke(System.Delegate d, params object[] args) { }
+    }
+    public sealed class WarningThreshold
+    {
+        public WarningThreshold() { }
+        public System.Action Handler { get; set; }
+        public System.TimeSpan Threshold { get; set; }
+    }
+    public class WorkCompletedEventArgs : System.EventArgs
+    {
+        public WorkCompletedEventArgs(bool cancelled) { }
+        public bool Cancelled { get; }
+    }
+}
+namespace Topics.Radical.Transactions
+{
+    
+    public sealed class TransactionEnlistmentHelper : System.IDisposable
+    {
+        public TransactionEnlistmentHelper() { }
+        public bool EnlistedInTransaction { get; }
+        public event System.EventHandler TransactionCompleted;
+        public event System.EventHandler TransactionEnlisted;
+        public void Dispose() { }
+        public void EnlistInTransaction(bool ensureTransaction, System.Transactions.IEnlistmentNotification enlistmentNotification, System.Transactions.EnlistmentOptions options) { }
+        protected override void Finalize() { }
+    }
+}
+namespace Topics.Radical.Validation
+{
+    
+    public class static ArrayEnsureExtension
+    {
+        public static Topics.Radical.Validation.IEnsure<T[]> ContainsIndex<T>(this Topics.Radical.Validation.IEnsure<T[]> validator, int index) { }
+    }
+    [System.FlagsAttribute()]
+    public enum Boundary
+    {
+        IncludeLower = 1,
+        ExcludeLower = 2,
+        IncludeHigher = 4,
+        ExcludeHigher = 8,
+        ExcludeBounds = 10,
+        IncludeBounds = 5,
+    }
+    public class static ComparableEnsureExtension
+    {
+        public static Topics.Radical.Validation.IEnsure<T> IsGreaterThen<T>(this Topics.Radical.Validation.IEnsure<T> validator, T expected)
+            where T : System.IComparable<> { }
+        public static Topics.Radical.Validation.IEnsure<T> IsGreaterThen<T>(this Topics.Radical.Validation.IEnsure<T> validator, T expected, Topics.Radical.Validation.Or boundaryBehavior)
+            where T : System.IComparable<> { }
+        public static Topics.Radical.Validation.IEnsure<T> IsSmallerThen<T>(this Topics.Radical.Validation.IEnsure<T> validator, T expected)
+            where T : System.IComparable<> { }
+        public static Topics.Radical.Validation.IEnsure<T> IsSmallerThen<T>(this Topics.Radical.Validation.IEnsure<T> validator, T expected, Topics.Radical.Validation.Or boundaryBehavior)
+            where T : System.IComparable<> { }
+        public static Topics.Radical.Validation.IEnsure<T> IsWithin<T>(this Topics.Radical.Validation.IEnsure<T> validator, T lowerBoundary, T higherBoundary)
+            where T : System.IComparable<> { }
+        public static Topics.Radical.Validation.IEnsure<T> IsWithin<T>(this Topics.Radical.Validation.IEnsure<T> validator, T lowerBoundary, T higherBoundary, Topics.Radical.Validation.Boundary boundaryBehavior)
+            where T : System.IComparable<> { }
+    }
+    public class static Ensure
+    {
+        public static Topics.Radical.Validation.SourceInfoLoadStrategy SourceInfoLoadStrategy { get; set; }
+        public static Topics.Radical.Validation.IConfigurableEnsure<T> That<T>(T obj) { }
+        public static Topics.Radical.Validation.IConfigurableEnsure<T> That<T>(T obj, Topics.Radical.Validation.SourceInfoLoadStrategy strategy) { }
+    }
+    public sealed class Ensure<T> : Topics.Radical.Validation.IConfigurableEnsure<T>, Topics.Radical.Validation.IEnsure<T>
+    
+    {
+        public string Name { get; }
+        public string UserErrorMessage { get; }
+        public T Value { get; }
+        public Topics.Radical.Validation.IEnsure<T> Else(System.Action<T> action) { }
+        public Topics.Radical.Validation.IEnsure<T> Else(System.Action<T, string> action) { }
+        public string GetFullErrorMessage(string validatorSpecificMessage) { }
+        public string GetFullErrorMessage() { }
+        public T GetValue() { }
+        public K GetValue<K>()
+            where K : T { }
+        public Topics.Radical.Validation.IEnsure<T> If(System.Predicate<T> predicate) { }
+        public Topics.Radical.Validation.IEnsure<T> Is(T value) { }
+        public Topics.Radical.Validation.IEnsure<T> IsFalse(System.Predicate<T> func) { }
+        public Topics.Radical.Validation.IEnsure<T> IsNot(T value) { }
+        public Topics.Radical.Validation.IEnsure<T> IsTrue(System.Predicate<T> func) { }
+        public Topics.Radical.Validation.IEnsure<T> Named(string parameterName) { }
+        public Topics.Radical.Validation.IEnsure<T> Named(System.Linq.Expressions.Expression<System.Func<T>> parameterName) { }
+        public Topics.Radical.Validation.IEnsure<T> Then(System.Action<T> action) { }
+        public Topics.Radical.Validation.IEnsure<T> Then(System.Action<T, string> action) { }
+        public Topics.Radical.Validation.IEnsure<T> ThenThrow(System.Func<Topics.Radical.Validation.IEnsure<T>, System.Exception> builder) { }
+        public void Throw(System.Exception error) { }
+        public Topics.Radical.Validation.IEnsure<T> WithMessage(string errorMessage) { }
+        public Topics.Radical.Validation.IEnsure<T> WithMessage(string errorMessage, params object[] formatArgs) { }
+        public Topics.Radical.Validation.IEnsure<T> WithPreview(System.Action<Topics.Radical.Validation.IEnsure<T>, System.Exception> validationFailurePreview) { }
+    }
+    public class static EnsureExtensions
+    {
+        public static Topics.Radical.Validation.IEnsure<T> IsNotNull<T>(this Topics.Radical.Validation.IEnsure<T> validator)
+            where T :  class { }
+    }
+    public class static EnumEnsureExtensions
+    {
+        public static Topics.Radical.Validation.IEnsure<T> IsDefined<T>(this Topics.Radical.Validation.IEnsure<T> validator) { }
+    }
+    public class static GuidEnsureExtension
+    {
+        public static Topics.Radical.Validation.IEnsure<System.Guid> IsNotEmpty(this Topics.Radical.Validation.IEnsure<System.Guid> validator) { }
+    }
+    public interface IConfigurableEnsure<T> : Topics.Radical.Validation.IEnsure<T>
+    
+    {
+        Topics.Radical.Validation.IEnsure<T> Named(System.Linq.Expressions.Expression<System.Func<T>> parameterName);
+        Topics.Radical.Validation.IEnsure<T> Named(string parameterName);
+    }
+    public interface IEnsure<T>
+    
+    {
+        string Name { get; }
+        string UserErrorMessage { get; }
+        T Value { get; }
+        Topics.Radical.Validation.IEnsure<T> Else(System.Action<T, string> action);
+        Topics.Radical.Validation.IEnsure<T> Else(System.Action<T> action);
+        string GetFullErrorMessage(string validatorSpecificMessage);
+        string GetFullErrorMessage();
+        T GetValue();
+        K GetValue<K>()
+            where K : T;
+        Topics.Radical.Validation.IEnsure<T> If(System.Predicate<T> predicate);
+        Topics.Radical.Validation.IEnsure<T> Is(T value);
+        Topics.Radical.Validation.IEnsure<T> IsFalse(System.Predicate<T> func);
+        Topics.Radical.Validation.IEnsure<T> IsNot(T value);
+        Topics.Radical.Validation.IEnsure<T> IsTrue(System.Predicate<T> func);
+        Topics.Radical.Validation.IEnsure<T> Then(System.Action<T, string> action);
+        Topics.Radical.Validation.IEnsure<T> Then(System.Action<T> action);
+        Topics.Radical.Validation.IEnsure<T> ThenThrow(System.Func<Topics.Radical.Validation.IEnsure<T>, System.Exception> builder);
+        void Throw(System.Exception error);
+        Topics.Radical.Validation.IEnsure<T> WithMessage(string errorMessage);
+        Topics.Radical.Validation.IEnsure<T> WithMessage(string errorMessage, params object[] formatArgs);
+        Topics.Radical.Validation.IEnsure<T> WithPreview(System.Action<Topics.Radical.Validation.IEnsure<T>, System.Exception> validationFailurePreview);
+    }
+    public enum Or
+    {
+        Equal = 0,
+        NotEqual = 1,
+    }
+    public enum SourceInfoLoadStrategy
+    {
+        Load = 0,
+        Skip = 1,
+        LazyLoad = 2,
+    }
+    public class static StringEnsureExtension
+    {
+        public static Topics.Radical.Validation.IEnsure<string> IsNotEmpty(this Topics.Radical.Validation.IEnsure<string> validator) { }
+        public static Topics.Radical.Validation.IEnsure<string> IsNotNullNorEmpty(this Topics.Radical.Validation.IEnsure<string> validator) { }
+        public static Topics.Radical.Validation.IEnsure<string> Matches(this Topics.Radical.Validation.IEnsure<string> validator, string regExPattern) { }
+    }
+    public class static TypeEnsureExtension
+    {
+        public static Topics.Radical.Validation.IEnsure<System.Type> Is<T>(this Topics.Radical.Validation.IEnsure<System.Type> validator) { }
+    }
+    public class ValidationContext<T>
+    
+    {
+        public ValidationContext(T entity, Topics.Radical.ComponentModel.Validation.IValidator<T> validator) { }
+        public ValidationContext(T entity, Topics.Radical.ComponentModel.Validation.IValidator<T> validator, Topics.Radical.Validation.ValidationResults results) { }
+        public T Entity { get; }
+        public string PropertyName { get; set; }
+        public Topics.Radical.Validation.ValidationResults Results { get; }
+        public string RuleSet { get; set; }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> Validator { get; }
+    }
+    public class ValidationError
+    {
+        public ValidationError(string key, string keyDisplayName, System.Collections.Generic.IEnumerable<string> detectedProblems) { }
+        public System.Collections.Generic.IEnumerable<string> DetectedProblems { get; }
+        public string Key { get; }
+        public string KeyDisplayName { get; }
+        public void AddProblems(System.Collections.Generic.IEnumerable<string> problems) { }
+        public static Topics.Radical.Validation.ValidationError Create<T>(System.Linq.Expressions.Expression<System.Func<T>> key, string keyDisplayName, params string[] detectedProblems) { }
+        public override string ToString() { }
+    }
+    public class static ValidationErrors
+    {
+        public static readonly System.Collections.Generic.IEnumerable<Topics.Radical.Validation.ValidationError> Empty;
+    }
+    public class ValidationResults
+    {
+        public static readonly Topics.Radical.Validation.ValidationResults Empty;
+        public ValidationResults() { }
+        public ValidationResults(System.Collections.Generic.IEnumerable<Topics.Radical.Validation.ValidationError> errors) { }
+        public System.Collections.Generic.IEnumerable<Topics.Radical.Validation.ValidationError> Errors { get; }
+        public bool IsValid { get; }
+        [System.ObsoleteAttribute("Use the overload without the evil \'params\' keyword using an explicit array: new[]" +
+            " { \'your error text here\' }.", true)]
+        public void AddError<T>(System.Linq.Expressions.Expression<System.Func<T>> key, params string[] detectedProblems) { }
+        public void AddError<T>(System.Linq.Expressions.Expression<System.Func<T>> key, string displayName, string[] detectedProblems) { }
+        public void AddError(Topics.Radical.Validation.ValidationError error) { }
+        public override string ToString() { }
+    }
+    public class ValidationTools
+    {
+        public ValidationTools() { }
+        public string GetPropertyDisplayName(string propertyName, object entity) { }
+    }
+    public class ValidatorBase<T> : Topics.Radical.ComponentModel.Validation.IValidator, Topics.Radical.ComponentModel.Validation.IValidator<T>
+    
+    {
+        public ValidatorBase(string ruleSet) { }
+        public string RuleSet { get; }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Action<Topics.Radical.Validation.ValidationContext<T>> rule) { }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Linq.Expressions.Expression<System.Func<T, object>> propertyIdentifier, System.Func<Topics.Radical.Validation.ValidationContext<T>, Topics.Radical.ComponentModel.Validation.RuleEvaluation> rule, string error) { }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> AddRule(System.Linq.Expressions.Expression<System.Func<T, object>> propertyIdentifier, System.Func<Topics.Radical.Validation.ValidationContext<T>, Topics.Radical.ComponentModel.Validation.RuleEvaluation> rule, System.Func<Topics.Radical.Validation.ValidationContext<T>, string> error) { }
+        protected virtual string GetPropertyDisplayName(string propertyName, object entity) { }
+        public bool IsValid(T entity) { }
+        protected virtual void OnValidate(Topics.Radical.Validation.ValidationContext<T> context) { }
+        public Topics.Radical.Validation.ValidationResults Validate(T entity) { }
+        public Topics.Radical.Validation.ValidationResults Validate(T entity, string propertyName) { }
+        public Topics.Radical.Validation.ValidationResults Validate<TProperty>(T entity, System.Linq.Expressions.Expression<System.Func<T, TProperty>> property) { }
+    }
+    public sealed class ValidatorBaseFactory : Topics.Radical.ComponentModel.Validation.IValidatorFactory
+    {
+        public ValidatorBaseFactory() { }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> CreateValidator<T>() { }
+        public Topics.Radical.ComponentModel.Validation.IValidator<T> CreateValidator<T>(string ruleSet) { }
+    }
+}
+namespace Topics.Radical.Win32
+{
+    
+    public class static Constants
+    {
+        public const int ACM_OPENA = 1124;
+        public const int ACM_OPENW = 1127;
+        public const int ADVF_NODATA = 1;
+        public const int ADVF_ONLYONCE = 2;
+        public const int ADVF_PRIMEFIRST = 4;
+        public const int ARW_BOTTOMLEFT = 0;
+        public const int ARW_BOTTOMRIGHT = 1;
+        public const int ARW_DOWN = 4;
+        public const int ARW_HIDE = 8;
+        public const int ARW_LEFT = 0;
+        public const int ARW_RIGHT = 0;
+        public const int ARW_TOPLEFT = 2;
+        public const int ARW_TOPRIGHT = 3;
+        public const int ARW_UP = 4;
+        public const int AUTOAPPEND = 1073741824;
+        public const int AUTOAPPEND_OFF = -2147483648;
+        public const int AUTOSUGGEST = 268435456;
+        public const int AUTOSUGGEST_OFF = 536870912;
+        public const int BCM_GETIDEALSIZE = 5633;
+        public const int BDR_RAISED = 5;
+        public const int BDR_RAISEDINNER = 4;
+        public const int BDR_RAISEDOUTER = 1;
+        public const int BDR_SUNKEN = 10;
+        public const int BDR_SUNKENINNER = 8;
+        public const int BDR_SUNKENOUTER = 2;
+        public const int BF_ADJUST = 8192;
+        public const int BF_BOTTOM = 8;
+        public const int BF_FLAT = 16384;
+        public const int BF_LEFT = 1;
+        public const int BF_MIDDLE = 2048;
+        public const int BF_RIGHT = 4;
+        public const int BF_TOP = 2;
+        public const int BFFM_ENABLEOK = 1125;
+        public const int BFFM_INITIALIZED = 1;
+        public const int BFFM_SELCHANGED = 2;
+        public const int BFFM_SETSELECTION = 1127;
+        public const int BI_RGB = 0;
+        public const int BITSPIXEL = 12;
+        public const int BM_CLICK = 245;
+        public const int BM_SETCHECK = 241;
+        public const int BM_SETSTATE = 243;
+        public const int BN_CLICKED = 0;
+        public const int BS_3STATE = 5;
+        public const int BS_BOTTOM = 2048;
+        public const int BS_CENTER = 768;
+        public const int BS_DEFPUSHBUTTON = 1;
+        public const int BS_GROUPBOX = 7;
+        public const int BS_LEFT = 256;
+        public const int BS_MULTILINE = 8192;
+        public const int BS_OWNERDRAW = 11;
+        public const int BS_PATTERN = 3;
+        public const int BS_PUSHBUTTON = 0;
+        public const int BS_PUSHLIKE = 4096;
+        public const int BS_RADIOBUTTON = 4;
+        public const int BS_RIGHT = 512;
+        public const int BS_RIGHTBUTTON = 32;
+        public const int BS_TOP = 1024;
+        public const int BS_VCENTER = 3072;
+        public const int CB_ADDSTRING = 323;
+        public const int CB_DELETESTRING = 324;
+        public const int CB_ERR = -1;
+        public const int CB_FINDSTRING = 332;
+        public const int CB_FINDSTRINGEXACT = 344;
+        public const int CB_GETCURSEL = 327;
+        public const int CB_GETDROPPEDSTATE = 343;
+        public const int CB_GETEDITSEL = 320;
+        public const int CB_GETITEMDATA = 336;
+        public const int CB_GETITEMHEIGHT = 340;
+        public const int CB_INSERTSTRING = 330;
+        public const int CB_LIMITTEXT = 321;
+        public const int CB_RESETCONTENT = 331;
+        public const int CB_SETCURSEL = 334;
+        public const int CB_SETDROPPEDWIDTH = 352;
+        public const int CB_SETEDITSEL = 322;
+        public const int CB_SETITEMHEIGHT = 339;
+        public const int CB_SHOWDROPDOWN = 335;
+        public const int CBEM_GETITEMA = 1028;
+        public const int CBEM_GETITEMW = 1037;
+        public const int CBEM_INSERTITEMA = 1025;
+        public const int CBEM_INSERTITEMW = 1035;
+        public const int CBEM_SETITEMA = 1029;
+        public const int CBEM_SETITEMW = 1036;
+        public const int CBEN_ENDEDITA = -805;
+        public const int CBEN_ENDEDITW = -806;
+        public const int CBN_CLOSEUP = 8;
+        public const int CBN_DBLCLK = 2;
+        public const int CBN_DROPDOWN = 7;
+        public const int CBN_EDITCHANGE = 5;
+        public const int CBN_EDITUPDATE = 6;
+        public const int CBN_SELCHANGE = 1;
+        public const int CBN_SELENDOK = 9;
+        public const int CBS_AUTOHSCROLL = 64;
+        public const int CBS_DROPDOWN = 2;
+        public const int CBS_DROPDOWNLIST = 3;
+        public const int CBS_HASSTRINGS = 512;
+        public const int CBS_NOINTEGRALHEIGHT = 1024;
+        public const int CBS_OWNERDRAWFIXED = 16;
+        public const int CBS_OWNERDRAWVARIABLE = 32;
+        public const int CBS_SIMPLE = 1;
+        public const int CC_ANYCOLOR = 256;
+        public const int CC_ENABLEHOOK = 16;
+        public const int CC_FULLOPEN = 2;
+        public const int CC_PREVENTFULLOPEN = 4;
+        public const int CC_RGBINIT = 1;
+        public const int CC_SHOWHELP = 8;
+        public const int CC_SOLIDCOLOR = 128;
+        public const int CCS_NODIVIDER = 64;
+        public const int CCS_NOPARENTALIGN = 8;
+        public const int CCS_NORESIZE = 4;
+        public const int CDDS_ITEM = 65536;
+        public const int CDDS_ITEMPOSTPAINT = 65538;
+        public const int CDDS_ITEMPREPAINT = 65537;
+        public const int CDDS_POSTPAINT = 2;
+        public const int CDDS_PREPAINT = 1;
+        public const int CDDS_SUBITEM = 131072;
+        public const int CDERR_DIALOGFAILURE = 65535;
+        public const int CDERR_FINDRESFAILURE = 6;
+        public const int CDERR_INITIALIZATION = 2;
+        public const int CDERR_LOADRESFAILURE = 7;
+        public const int CDERR_LOADSTRFAILURE = 5;
+        public const int CDERR_LOCKRESFAILURE = 8;
+        public const int CDERR_MEMALLOCFAILURE = 9;
+        public const int CDERR_MEMLOCKFAILURE = 10;
+        public const int CDERR_NOHINSTANCE = 4;
+        public const int CDERR_NOHOOK = 11;
+        public const int CDERR_NOTEMPLATE = 3;
+        public const int CDERR_REGISTERMSGFAIL = 12;
+        public const int CDERR_STRUCTSIZE = 1;
+        public const int CDIS_CHECKED = 8;
+        public const int CDIS_DEFAULT = 32;
+        public const int CDIS_DISABLED = 4;
+        public const int CDIS_FOCUS = 16;
+        public const int CDIS_GRAYED = 2;
+        public const int CDIS_HOT = 64;
+        public const int CDIS_INDETERMINATE = 256;
+        public const int CDIS_MARKED = 128;
+        public const int CDIS_SELECTED = 1;
+        public const int CDIS_SHOWKEYBOARDCUES = 512;
+        public const int CDRF_DODEFAULT = 0;
+        public const int CDRF_NEWFONT = 2;
+        public const int CDRF_NOTIFYITEMDRAW = 32;
+        public const int CDRF_NOTIFYPOSTPAINT = 16;
+        public const int CDRF_NOTIFYSUBITEMDRAW = 32;
+        public const int CDRF_SKIPDEFAULT = 4;
+        public const int CF_APPLY = 512;
+        public const int CF_BITMAP = 2;
+        public const int CF_DIB = 8;
+        public const int CF_DIF = 5;
+        public const int CF_EFFECTS = 256;
+        public const int CF_ENABLEHOOK = 8;
+        public const int CF_ENHMETAFILE = 14;
+        public const int CF_FIXEDPITCHONLY = 16384;
+        public const int CF_FORCEFONTEXIST = 65536;
+        public const int CF_HDROP = 15;
+        public const int CF_INITTOLOGFONTSTRUCT = 64;
+        public const int CF_LIMITSIZE = 8192;
+        public const int CF_LOCALE = 16;
+        public const int CF_METAFILEPICT = 3;
+        public const int CF_NOSIMULATIONS = 4096;
+        public const int CF_NOVECTORFONTS = 2048;
+        public const int CF_NOVERTFONTS = 16777216;
+        public const int CF_OEMTEXT = 7;
+        public const int CF_PALETTE = 9;
+        public const int CF_PENDATA = 10;
+        public const int CF_RIFF = 11;
+        public const int CF_SCREENFONTS = 1;
+        public const int CF_SCRIPTSONLY = 1024;
+        public const int CF_SELECTSCRIPT = 4194304;
+        public const int CF_SHOWHELP = 4;
+        public const int CF_SYLK = 4;
+        public const int CF_TEXT = 1;
+        public const int CF_TIFF = 6;
+        public const int CF_TTONLY = 262144;
+        public const int CF_UNICODETEXT = 13;
+        public const int CF_WAVE = 12;
+        public const int CFERR_MAXLESSTHANMIN = 8194;
+        public const int CFERR_NOFONTS = 8193;
+        public const int CLR_DEFAULT = -16777216;
+        public const int CLR_NONE = -1;
+        public const int CLSCTX_INPROC_SERVER = 1;
+        public const int CLSCTX_LOCAL_SERVER = 4;
+        public const int cmb4 = 1139;
+        public const int COLOR_WINDOW = 5;
+        public const int CONNECT_E_CANNOTCONNECT = -2147220990;
+        public const int CONNECT_E_NOCONNECTION = -2147220992;
+        public const int CP_WINANSI = 1004;
+        public const int CS_DBLCLKS = 8;
+        public const int CS_DROPSHADOW = 131072;
+        public const int CSC_NAVIGATEBACK = 2;
+        public const int CSC_NAVIGATEFORWARD = 1;
+        public const int CSIDL_APPDATA = 26;
+        public const int CSIDL_COMMON_APPDATA = 35;
+        public const int CSIDL_COOKIES = 33;
+        public const int CSIDL_DESKTOP = 0;
+        public const int CSIDL_DESKTOPDIRECTORY = 16;
+        public const int CSIDL_FAVORITES = 6;
+        public const int CSIDL_HISTORY = 34;
+        public const int CSIDL_INTERNET = 1;
+        public const int CSIDL_INTERNET_CACHE = 32;
+        public const int CSIDL_LOCAL_APPDATA = 28;
+        public const int CSIDL_PERSONAL = 5;
+        public const int CSIDL_PROGRAM_FILES = 38;
+        public const int CSIDL_PROGRAM_FILES_COMMON = 43;
+        public const int CSIDL_PROGRAMS = 2;
+        public const int CSIDL_RECENT = 8;
+        public const int CSIDL_SENDTO = 9;
+        public const int CSIDL_STARTMENU = 11;
+        public const int CSIDL_STARTUP = 7;
+        public const int CSIDL_SYSTEM = 37;
+        public const int CSIDL_TEMPLATES = 21;
+        public const int CTRLINFO_EATS_ESCAPE = 2;
+        public const int CTRLINFO_EATS_RETURN = 1;
+        public const int CW_USEDEFAULT = -2147483648;
+        public const int CWP_SKIPINVISIBLE = 1;
+        public const int DCX_CACHE = 2;
+        public const int DCX_LOCKWINDOWUPDATE = 1024;
+        public const int DCX_WINDOW = 1;
+        public const int DEFAULT_GUI_FONT = 17;
+        public const int DFC_BUTTON = 4;
+        public const int DFC_CAPTION = 1;
+        public const int DFC_MENU = 2;
+        public const int DFC_SCROLL = 3;
+        public const int DFCS_BUTTON3STATE = 8;
+        public const int DFCS_BUTTONCHECK = 0;
+        public const int DFCS_BUTTONPUSH = 16;
+        public const int DFCS_BUTTONRADIO = 4;
+        public const int DFCS_CAPTIONCLOSE = 0;
+        public const int DFCS_CAPTIONHELP = 4;
+        public const int DFCS_CAPTIONMAX = 2;
+        public const int DFCS_CAPTIONMIN = 1;
+        public const int DFCS_CAPTIONRESTORE = 3;
+        public const int DFCS_CHECKED = 1024;
+        public const int DFCS_FLAT = 16384;
+        public const int DFCS_INACTIVE = 256;
+        public const int DFCS_MENUARROW = 0;
+        public const int DFCS_MENUBULLET = 2;
+        public const int DFCS_MENUCHECK = 1;
+        public const int DFCS_PUSHED = 512;
+        public const int DFCS_SCROLLCOMBOBOX = 5;
+        public const int DFCS_SCROLLDOWN = 1;
+        public const int DFCS_SCROLLLEFT = 2;
+        public const int DFCS_SCROLLRIGHT = 3;
+        public const int DFCS_SCROLLUP = 0;
+        public const int DI_NORMAL = 3;
+        public const int DIB_RGB_COLORS = 0;
+        public const int DISP_E_EXCEPTION = -2147352567;
+        public const int DISP_E_MEMBERNOTFOUND = -2147352573;
+        public const int DISP_E_PARAMNOTFOUND = -2147352572;
+        public const int DISPATCH_METHOD = 1;
+        public const int DISPATCH_PROPERTYGET = 2;
+        public const int DISPATCH_PROPERTYPUT = 4;
+        public const int DISPID_PROPERTYPUT = -3;
+        public const int DISPID_UNKNOWN = -1;
+        public const int DLGC_WANTALLKEYS = 4;
+        public const int DLGC_WANTARROWS = 1;
+        public const int DLGC_WANTCHARS = 128;
+        public const int DLGC_WANTTAB = 2;
+        public const int DRAGDROP_E_ALREADYREGISTERED = -2147221247;
+        public const int DRAGDROP_E_NOTREGISTERED = -2147221248;
+        public const int DT_CALCRECT = 1024;
+        public const int DT_EDITCONTROL = 8192;
+        public const int DT_END_ELLIPSIS = 32768;
+        public const int DT_EXPANDTABS = 64;
+        public const int DT_LEFT = 0;
+        public const int DT_NOCLIP = 256;
+        public const int DT_NOPREFIX = 2048;
+        public const int DT_RIGHT = 2;
+        public const int DT_RTLREADING = 131072;
+        public const int DT_SINGLELINE = 32;
+        public const int DT_VCENTER = 4;
+        public const int DT_WORDBREAK = 16;
+        public const int DTM_SETFORMATA = 4101;
+        public const int DTM_SETFORMATW = 4146;
+        public const int DTM_SETMCCOLOR = 4102;
+        public const int DTM_SETMCFONT = 4105;
+        public const int DTM_SETRANGE = 4100;
+        public const int DTM_SETSYSTEMTIME = 4098;
+        public const int DTN_CLOSEUP = -753;
+        public const int DTN_DATETIMECHANGE = -759;
+        public const int DTN_DROPDOWN = -754;
+        public const int DTN_FORMATA = -756;
+        public const int DTN_FORMATQUERYA = -755;
+        public const int DTN_FORMATQUERYW = -742;
+        public const int DTN_FORMATW = -743;
+        public const int DTN_USERSTRINGA = -758;
+        public const int DTN_USERSTRINGW = -745;
+        public const int DTN_WMKEYDOWNA = -757;
+        public const int DTN_WMKEYDOWNW = -744;
+        public const int DTS_LONGDATEFORMAT = 4;
+        public const int DTS_RIGHTALIGN = 32;
+        public const int DTS_SHOWNONE = 2;
+        public const int DTS_TIMEFORMAT = 9;
+        public const int DTS_UPDOWN = 1;
+        public const int DUPLICATE = 6;
+        public const int DUPLICATE_SAME_ACCESS = 2;
+        public const int DV_E_DVASPECT = -2147221397;
+        public const int DVASPECT_CONTENT = 1;
+        public const int DVASPECT_OPAQUE = 16;
+        public const int DVASPECT_TRANSPARENT = 32;
+        public const int E_ABORT = -2147467260;
+        public const int E_FAIL = -2147467259;
+        public const int E_INVALIDARG = -2147024809;
+        public const int E_NOINTERFACE = -2147467262;
+        public const int E_NOTIMPL = -2147467263;
+        public const int E_OUTOFMEMORY = -2147024882;
+        public const int E_UNEXPECTED = -2147418113;
+        public const int EC_LEFTMARGIN = 1;
+        public const int EC_RIGHTMARGIN = 2;
+        public const int ECM_FIRST = 5376;
+        public const int EDGE_BUMP = 9;
+        public const int EDGE_ETCHED = 6;
+        public const int EDGE_RAISED = 5;
+        public const int EDGE_SUNKEN = 10;
+        public const int EM_CANUNDO = 198;
+        public const int EM_CHARFROMPOS = 215;
+        public const int EM_EMPTYUNDOBUFFER = 205;
+        public const int EM_GETLINE = 196;
+        public const int EM_GETLINECOUNT = 186;
+        public const int EM_GETMODIFY = 184;
+        public const int EM_GETPASSWORDCHAR = 210;
+        public const int EM_GETSEL = 176;
+        public const int EM_LIMITTEXT = 197;
+        public const int EM_LINEFROMCHAR = 201;
+        public const int EM_LINEINDEX = 187;
+        public const int EM_POSFROMCHAR = 214;
+        public const int EM_REPLACESEL = 194;
+        public const int EM_SCROLL = 181;
+        public const int EM_SCROLLCARET = 183;
+        public const int EM_SETCUEBANNER = 5377;
+        public const int EM_SETMARGINS = 211;
+        public const int EM_SETMODIFY = 185;
+        public const int EM_SETPASSWORDCHAR = 204;
+        public const int EM_SETREADONLY = 207;
+        public const int EM_SETSEL = 177;
+        public const int EM_UNDO = 199;
+        public const int EMR_POLYTEXTOUTA = 96;
+        public const int EMR_POLYTEXTOUTW = 97;
+        public const int EN_ALIGN_LTR_EC = 1792;
+        public const int EN_ALIGN_RTL_EC = 1793;
+        public const int EN_CHANGE = 768;
+        public const int EN_HSCROLL = 1537;
+        public const int EN_VSCROLL = 1538;
+        public const int ES_AUTOHSCROLL = 128;
+        public const int ES_AUTOVSCROLL = 64;
+        public const int ES_CENTER = 1;
+        public const int ES_LEFT = 0;
+        public const int ES_LOWERCASE = 16;
+        public const int ES_MULTILINE = 4;
+        public const int ES_NOHIDESEL = 256;
+        public const int ES_NUMBER = 8192;
+        public const int ES_PASSWORD = 32;
+        public const int ES_READONLY = 2048;
+        public const int ES_RIGHT = 2;
+        public const int ES_UPPERCASE = 8;
+        public const int ETO_CLIPPED = 4;
+        public const int ETO_OPAQUE = 2;
+        public const int FADF_BSTR = 256;
+        public const int FADF_DISPATCH = 1024;
+        public const int FADF_UNKNOWN = 512;
+        public const int FADF_VARIANT = 2048;
+        public const int FALT = 16;
+        public const int FLASHW_ALL = 3;
+        public const int FLASHW_CAPTION = 1;
+        public const int FLASHW_STOP = 0;
+        public const int FLASHW_TIMER = 4;
+        public const int FLASHW_TIMERNOFG = 12;
+        public const int FLASHW_TRAY = 2;
+        public const int FNERR_BUFFERTOOSMALL = 12291;
+        public const int FNERR_INVALIDFILENAME = 12290;
+        public const int FNERR_SUBCLASSFAILURE = 12289;
+        public const int FORMAT_MESSAGE_FROM_SYSTEM = 4096;
+        public const int FORMAT_MESSAGE_IGNORE_INSERTS = 512;
+        public const int FRERR_BUFFERLENGTHZERO = 16385;
+        public const int FSHIFT = 4;
+        public const int FVIRTKEY = 1;
+        public const int GDI_ERROR = -1;
+        public const int GDT_NONE = 1;
+        public const int GDT_VALID = 0;
+        public const int GDTR_MAX = 2;
+        public const int GDTR_MIN = 1;
+        public const int GMEM_DDESHARE = 8192;
+        public const int GMEM_MOVEABLE = 2;
+        public const int GMEM_ZEROINIT = 64;
+        public const int GMR_DAYSTATE = 1;
+        public const int GMR_VISIBLE = 0;
+        public const int GW_CHILD = 5;
+        public const int GW_HWNDFIRST = 0;
+        public const int GW_HWNDLAST = 1;
+        public const int GW_HWNDNEXT = 2;
+        public const int GW_HWNDPREV = 3;
+        public const int GWL_EXSTYLE = -20;
+        public const int GWL_HWNDPARENT = -8;
+        public const int GWL_ID = -12;
+        public const int GWL_STYLE = -16;
+        public const int GWL_WNDPROC = -4;
+        public const int HC_ACTION = 0;
+        public const int HC_GETNEXT = 1;
+        public const int HC_SKIP = 2;
+        public const int HCF_HIGHCONTRASTON = 1;
+        public const int HDI_ORDER = 128;
+        public const int HDM_GETITEMA = 4611;
+        public const int HDM_GETITEMCOUNT = 4608;
+        public const int HDM_GETITEMW = 4619;
+        public const int HDM_INSERTITEMA = 4609;
+        public const int HDM_INSERTITEMW = 4618;
+        public const int HDM_SETITEMA = 4612;
+        public const int HDM_SETITEMW = 4620;
+        public const int HDN_BEGINTDRAG = -310;
+        public const int HDN_BEGINTRACKA = -306;
+        public const int HDN_BEGINTRACKW = -326;
+        public const int HDN_DIVIDERDBLCLICKA = -305;
+        public const int HDN_DIVIDERDBLCLICKW = -325;
+        public const int HDN_ENDDRAG = -311;
+        public const int HDN_ENDTRACKA = -307;
+        public const int HDN_ENDTRACKW = -327;
+        public const int HDN_GETDISPINFOA = -309;
+        public const int HDN_GETDISPINFOW = -329;
+        public const int HDN_ITEMCHANGEDA = -301;
+        public const int HDN_ITEMCHANGEDW = -321;
+        public const int HDN_ITEMCHANGINGA = -300;
+        public const int HDN_ITEMCHANGINGW = -320;
+        public const int HDN_ITEMCLICKA = -302;
+        public const int HDN_ITEMCLICKW = -322;
+        public const int HDN_ITEMDBLCLICKA = -303;
+        public const int HDN_ITEMDBLCLICKW = -323;
+        public const int HDN_TRACKA = -308;
+        public const int HDN_TRACKW = -328;
+        public const int HELPINFO_WINDOW = 1;
+        public const int HLP_FILE = 1;
+        public const int HLP_KEYWORD = 2;
+        public const int HLP_NAVIGATOR = 3;
+        public const int HLP_OBJECT = 4;
+        public const int HOLLOW_BRUSH = 5;
+        public const int HTBOTTOM = 15;
+        public const int HTBOTTOMRIGHT = 17;
+        public const int HTCAPTION = 2;
+        public const int HTCLIENT = 1;
+        public const int HTNOWHERE = 0;
+        public const int HTTRANSPARENT = -1;
+        public const int ICC_BAR_CLASSES = 4;
+        public const int ICC_DATE_CLASSES = 256;
+        public const int ICC_LISTVIEW_CLASSES = 1;
+        public const int ICC_PROGRESS_CLASS = 32;
+        public const int ICC_TAB_CLASSES = 8;
+        public const int ICC_TREEVIEW_CLASSES = 2;
+        public const int ICON_BIG = 1;
+        public const int ICON_SMALL = 0;
+        public const int IDC_APPSTARTING = 32650;
+        public const int IDC_ARROW = 32512;
+        public const int IDC_CROSS = 32515;
+        public const int IDC_HELP = 32651;
+        public const int IDC_IBEAM = 32513;
+        public const int IDC_NO = 32648;
+        public const int IDC_SIZEALL = 32646;
+        public const int IDC_SIZENESW = 32643;
+        public const int IDC_SIZENS = 32645;
+        public const int IDC_SIZENWSE = 32642;
+        public const int IDC_SIZEWE = 32644;
+        public const int IDC_UPARROW = 32516;
+        public const int IDC_WAIT = 32514;
+        public const int IDM_PAGESETUP = 2004;
+        public const int IDM_PRINT = 27;
+        public const int IDM_PRINTPREVIEW = 2003;
+        public const int IDM_PROPERTIES = 28;
+        public const int IDM_SAVEAS = 71;
+        public const int ILC_COLOR = 0;
+        public const int ILC_COLOR16 = 16;
+        public const int ILC_COLOR24 = 24;
+        public const int ILC_COLOR32 = 32;
+        public const int ILC_COLOR4 = 4;
+        public const int ILC_COLOR8 = 8;
+        public const int ILC_MASK = 1;
+        public const int ILD_MASK = 16;
+        public const int ILD_NORMAL = 0;
+        public const int ILD_ROP = 64;
+        public const int ILD_TRANSPARENT = 1;
+        public const int ILS_ALPHA = 8;
+        public const int ILS_GLOW = 1;
+        public const int ILS_NORMAL = 0;
+        public const int ILS_SATURATE = 4;
+        public const int ILS_SHADOW = 2;
+        public const int IMAGE_CURSOR = 2;
+        public const int IMAGE_ICON = 1;
+        public const int IME_CMODE_FULLSHAPE = 8;
+        public const int IME_CMODE_KATAKANA = 2;
+        public const int IME_CMODE_NATIVE = 1;
+        public const int INET_E_DEFAULT_ACTION = -2146697199;
+        public const int INPLACE_E_NOTOOLSPACE = -2147221087;
+        public const int KEYEVENTF_KEYUP = 2;
+        public const int LANG_NEUTRAL = 0;
+        public const int LB_ADDSTRING = 384;
+        public const int LB_DELETESTRING = 386;
+        public const int LB_ERR = -1;
+        public const int LB_ERRSPACE = -2;
+        public const int LB_FINDSTRING = 399;
+        public const int LB_FINDSTRINGEXACT = 418;
+        public const int LB_GETCARETINDEX = 415;
+        public const int LB_GETCURSEL = 392;
+        public const int LB_GETITEMHEIGHT = 417;
+        public const int LB_GETITEMRECT = 408;
+        public const int LB_GETSEL = 391;
+        public const int LB_GETSELCOUNT = 400;
+        public const int LB_GETSELITEMS = 401;
+        public const int LB_GETTEXT = 393;
+        public const int LB_GETTEXTLEN = 394;
+        public const int LB_GETTOPINDEX = 398;
+        public const int LB_INSERTSTRING = 385;
+        public const int LB_ITEMFROMPOINT = 425;
+        public const int LB_RESETCONTENT = 388;
+        public const int LB_SETCOLUMNWIDTH = 405;
+        public const int LB_SETCURSEL = 390;
+        public const int LB_SETHORIZONTALEXTENT = 404;
+        public const int LB_SETITEMHEIGHT = 416;
+        public const int LB_SETLOCALE = 421;
+        public const int LB_SETSEL = 389;
+        public const int LB_SETTABSTOPS = 402;
+        public const int LB_SETTOPINDEX = 407;
+        public const int LBN_DBLCLK = 2;
+        public const int LBN_SELCHANGE = 1;
+        public const int LBS_DISABLENOSCROLL = 4096;
+        public const int LBS_EXTENDEDSEL = 2048;
+        public const int LBS_HASSTRINGS = 64;
+        public const int LBS_MULTICOLUMN = 512;
+        public const int LBS_MULTIPLESEL = 8;
+        public const int LBS_NOINTEGRALHEIGHT = 256;
+        public const int LBS_NOSEL = 16384;
+        public const int LBS_NOTIFY = 1;
+        public const int LBS_OWNERDRAWFIXED = 16;
+        public const int LBS_OWNERDRAWVARIABLE = 32;
+        public const int LBS_USETABSTOPS = 128;
+        public const int LBS_WANTKEYBOARDINPUT = 1024;
+        public const int LLKHF_ALTDOWN = 32;
+        public const int LLKHF_EXTENDED = 1;
+        public const int LLKHF_INJECTED = 16;
+        public const int LLKHF_UP = 128;
+        public const int LOCALE_IFIRSTDAYOFWEEK = 4108;
+        public const int LOCK_EXCLUSIVE = 2;
+        public const int LOCK_ONLYONCE = 4;
+        public const int LOCK_WRITE = 1;
+        public const int LOGPIXELSX = 88;
+        public const int LOGPIXELSY = 90;
+        public const int LV_VIEW_TILE = 4;
+        public const int LVA_ALIGNLEFT = 1;
+        public const int LVA_ALIGNTOP = 2;
+        public const int LVA_DEFAULT = 0;
+        public const int LVA_SNAPTOGRID = 5;
+        public const int LVBKIF_SOURCE_NONE = 0;
+        public const int LVBKIF_SOURCE_URL = 2;
+        public const int LVBKIF_STYLE_NORMAL = 0;
+        public const int LVBKIF_STYLE_TILE = 16;
+        public const int LVCDI_ITEM = 0;
+        public const int LVCF_FMT = 1;
+        public const int LVCF_IMAGE = 16;
+        public const int LVCF_ORDER = 32;
+        public const int LVCF_SUBITEM = 8;
+        public const int LVCF_TEXT = 4;
+        public const int LVCF_WIDTH = 2;
+        public const int LVFI_NEARESTXY = 64;
+        public const int LVFI_PARAM = 1;
+        public const int LVFI_PARTIAL = 8;
+        public const int LVFI_STRING = 2;
+        public const int LVGA_FOOTER_CENTER = 16;
+        public const int LVGA_FOOTER_LEFT = 8;
+        public const int LVGA_FOOTER_RIGHT = 32;
+        public const int LVGA_HEADER_CENTER = 2;
+        public const int LVGA_HEADER_LEFT = 1;
+        public const int LVGA_HEADER_RIGHT = 4;
+        public const int LVGF_ALIGN = 8;
+        public const int LVGF_FOOTER = 2;
+        public const int LVGF_GROUPID = 16;
+        public const int LVGF_HEADER = 1;
+        public const int LVGF_NONE = 0;
+        public const int LVGF_STATE = 4;
+        public const int LVGS_COLLAPSED = 1;
+        public const int LVGS_HIDDEN = 2;
+        public const int LVGS_NORMAL = 0;
+        public const int LVHT_ABOVE = 8;
+        public const int LVHT_BELOW = 16;
+        public const int LVHT_LEFT = 64;
+        public const int LVHT_NOWHERE = 1;
+        public const int LVHT_ONITEM = 14;
+        public const int LVHT_ONITEMICON = 2;
+        public const int LVHT_ONITEMLABEL = 4;
+        public const int LVHT_ONITEMSTATEICON = 8;
+        public const int LVHT_RIGHT = 32;
+        public const int LVIF_COLUMNS = 512;
+        public const int LVIF_GROUPID = 256;
+        public const int LVIF_IMAGE = 2;
+        public const int LVIF_INDENT = 16;
+        public const int LVIF_PARAM = 4;
+        public const int LVIF_STATE = 8;
+        public const int LVIF_TEXT = 1;
+        public const int LVIM_AFTER = 1;
+        public const int LVIR_BOUNDS = 0;
+        public const int LVIR_ICON = 1;
+        public const int LVIR_LABEL = 2;
+        public const int LVIR_SELECTBOUNDS = 3;
+        public const int LVIS_CUT = 4;
+        public const int LVIS_DROPHILITED = 8;
+        public const int LVIS_FOCUSED = 1;
+        public const int LVIS_OVERLAYMASK = 3840;
+        public const int LVIS_SELECTED = 2;
+        public const int LVIS_STATEIMAGEMASK = 61440;
+        public const int LVM_ARRANGE = 4118;
+        public const int LVM_DELETEALLITEMS = 4105;
+        public const int LVM_DELETECOLUMN = 4124;
+        public const int LVM_DELETEITEM = 4104;
+        public const int LVM_EDITLABELA = 4119;
+        public const int LVM_EDITLABELW = 4214;
+        public const int LVM_ENABLEGROUPVIEW = 4253;
+        public const int LVM_ENSUREVISIBLE = 4115;
+        public const int LVM_FINDITEMA = 4109;
+        public const int LVM_FINDITEMW = 4179;
+        public const int LVM_FIRST = 4096;
+        public const int LVM_GETCOLUMNA = 4121;
+        public const int LVM_GETCOLUMNW = 4191;
+        public const int LVM_GETCOLUMNWIDTH = 4125;
+        public const int LVM_GETGROUPINFO = 4245;
+        public const int LVM_GETHEADER = 4127;
+        public const int LVM_GETHOTITEM = 4157;
+        public const int LVM_GETINSERTMARK = 4263;
+        public const int LVM_GETINSERTMARKCOLOR = 4267;
+        public const int LVM_GETINSERTMARKRECT = 4265;
+        public const int LVM_GETISEARCHSTRINGA = 4148;
+        public const int LVM_GETISEARCHSTRINGW = 4213;
+        public const int LVM_GETITEMA = 4101;
+        public const int LVM_GETITEMRECT = 4110;
+        public const int LVM_GETITEMSTATE = 4140;
+        public const int LVM_GETITEMTEXTA = 4141;
+        public const int LVM_GETITEMTEXTW = 4211;
+        public const int LVM_GETITEMW = 4171;
+        public const int LVM_GETNEXTITEM = 4108;
+        public const int LVM_GETSELECTEDCOUNT = 4146;
+        public const int LVM_GETSTRINGWIDTHA = 4113;
+        public const int LVM_GETSTRINGWIDTHW = 4183;
+        public const int LVM_GETSUBITEMRECT = 4152;
+        public const int LVM_GETTILEVIEWINFO = 4259;
+        public const int LVM_GETTOPINDEX = 4135;
+        public const int LVM_HASGROUP = 4257;
+        public const int LVM_HITTEST = 4114;
+        public const int LVM_INSERTCOLUMNA = 4123;
+        public const int LVM_INSERTCOLUMNW = 4193;
+        public const int LVM_INSERTGROUP = 4241;
+        public const int LVM_INSERTITEMA = 4103;
+        public const int LVM_INSERTITEMW = 4173;
+        public const int LVM_INSERTMARKHITTEST = 4264;
+        public const int LVM_ISGROUPVIEWENABLED = 4271;
+        public const int LVM_MOVEITEMTOGROUP = 4250;
+        public const int LVM_REDRAWITEMS = 4117;
+        public const int LVM_REMOVEALLGROUPS = 4256;
+        public const int LVM_REMOVEGROUP = 4246;
+        public const int LVM_SCROLL = 4116;
+        public const int LVM_SETBKCOLOR = 4097;
+        public const int LVM_SETBKIMAGEA = 4164;
+        public const int LVM_SETBKIMAGEW = 4234;
+        public const int LVM_SETCOLUMNA = 4122;
+        public const int LVM_SETCOLUMNW = 4192;
+        public const int LVM_SETCOLUMNWIDTH = 4126;
+        public const int LVM_SETEXTENDEDLISTVIEWSTYLE = 4150;
+        public const int LVM_SETGROUPINFO = 4243;
+        public const int LVM_SETIMAGELIST = 4099;
+        public const int LVM_SETINFOTIP = 4269;
+        public const int LVM_SETINSERTMARK = 4262;
+        public const int LVM_SETINSERTMARKCOLOR = 4266;
+        public const int LVM_SETITEMA = 4102;
+        public const int LVM_SETITEMCOUNT = 4143;
+        public const int LVM_SETITEMPOSITION = 4111;
+        public const int LVM_SETITEMPOSITION32 = 4145;
+        public const int LVM_SETITEMSTATE = 4139;
+        public const int LVM_SETITEMTEXTA = 4142;
+        public const int LVM_SETITEMTEXTW = 4212;
+        public const int LVM_SETITEMW = 4172;
+        public const int LVM_SETTEXTBKCOLOR = 4134;
+        public const int LVM_SETTEXTCOLOR = 4132;
+        public const int LVM_SETTILEVIEWINFO = 4258;
+        public const int LVM_SETTOOLTIPS = 4170;
+        public const int LVM_SETVIEW = 4238;
+        public const int LVM_SORTITEMS = 4144;
+        public const int LVM_SUBITEMHITTEST = 4153;
+        public const int LVM_UPDATE = 4138;
+        public const int LVN_BEGINDRAG = -109;
+        public const int LVN_BEGINLABELEDITA = -105;
+        public const int LVN_BEGINLABELEDITW = -175;
+        public const int LVN_BEGINRDRAG = -111;
+        public const int LVN_COLUMNCLICK = -108;
+        public const int LVN_ENDLABELEDITA = -106;
+        public const int LVN_ENDLABELEDITW = -176;
+        public const int LVN_GETDISPINFOA = -150;
+        public const int LVN_GETDISPINFOW = -177;
+        public const int LVN_GETINFOTIPA = -157;
+        public const int LVN_GETINFOTIPW = -158;
+        public const int LVN_ITEMACTIVATE = -114;
+        public const int LVN_ITEMCHANGED = -101;
+        public const int LVN_ITEMCHANGING = -100;
+        public const int LVN_KEYDOWN = -155;
+        public const int LVN_ODCACHEHINT = -113;
+        public const int LVN_ODFINDITEMA = -152;
+        public const int LVN_ODFINDITEMW = -179;
+        public const int LVN_ODSTATECHANGED = -115;
+        public const int LVN_SETDISPINFOA = -151;
+        public const int LVN_SETDISPINFOW = -178;
+        public const int LVNI_FOCUSED = 1;
+        public const int LVNI_SELECTED = 2;
+        public const int LVS_ALIGNLEFT = 2048;
+        public const int LVS_ALIGNTOP = 0;
+        public const int LVS_AUTOARRANGE = 256;
+        public const int LVS_EDITLABELS = 512;
+        public const int LVS_EX_CHECKBOXES = 4;
+        public const int LVS_EX_FULLROWSELECT = 32;
+        public const int LVS_EX_GRIDLINES = 1;
+        public const int LVS_EX_HEADERDRAGDROP = 16;
+        public const int LVS_EX_INFOTIP = 1024;
+        public const int LVS_EX_ONECLICKACTIVATE = 64;
+        public const int LVS_EX_TRACKSELECT = 8;
+        public const int LVS_EX_TWOCLICKACTIVATE = 128;
+        public const int LVS_EX_UNDERLINEHOT = 2048;
+        public const int LVS_ICON = 0;
+        public const int LVS_LIST = 3;
+        public const int LVS_NOCOLUMNHEADER = 16384;
+        public const int LVS_NOLABELWRAP = 128;
+        public const int LVS_NOSCROLL = 8192;
+        public const int LVS_NOSORTHEADER = 32768;
+        public const int LVS_OWNERDATA = 4096;
+        public const int LVS_REPORT = 1;
+        public const int LVS_SHAREIMAGELISTS = 64;
+        public const int LVS_SHOWSELALWAYS = 8;
+        public const int LVS_SINGLESEL = 4;
+        public const int LVS_SMALLICON = 2;
+        public const int LVS_SORTASCENDING = 16;
+        public const int LVS_SORTDESCENDING = 32;
+        public const int LVSCW_AUTOSIZE = -1;
+        public const int LVSCW_AUTOSIZE_USEHEADER = -2;
+        public const int LVSIL_NORMAL = 0;
+        public const int LVSIL_SMALL = 1;
+        public const int LVSIL_STATE = 2;
+        public const int LVTVIF_FIXEDSIZE = 3;
+        public const int LVTVIM_COLUMNS = 2;
+        public const int LVTVIM_TILESIZE = 1;
+        public const int LWA_ALPHA = 2;
+        public const int LWA_COLORKEY = 1;
+        public const int MAX_PATH = 260;
+        public const int MB_ICONASTERISK = 64;
+        public const int MB_ICONEXCLAMATION = 48;
+        public const int MB_ICONHAND = 16;
+        public const int MB_ICONQUESTION = 32;
+        public const int MB_OK = 0;
+        public const int MCHT_CALENDAR = 131072;
+        public const int MCHT_CALENDARBK = 131072;
+        public const int MCHT_CALENDARDATE = 131073;
+        public const int MCHT_CALENDARDATENEXT = 16908289;
+        public const int MCHT_CALENDARDATEPREV = 33685505;
+        public const int MCHT_CALENDARDAY = 131074;
+        public const int MCHT_CALENDARWEEKNUM = 131075;
+        public const int MCHT_TITLE = 65536;
+        public const int MCHT_TITLEBK = 65536;
+        public const int MCHT_TITLEBTNNEXT = 16842755;
+        public const int MCHT_TITLEBTNPREV = 33619971;
+        public const int MCHT_TITLEMONTH = 65537;
+        public const int MCHT_TITLEYEAR = 65538;
+        public const int MCHT_TODAYLINK = 196608;
+        public const int MCM_GETMAXTODAYWIDTH = 4117;
+        public const int MCM_GETMINREQRECT = 4105;
+        public const int MCM_GETMONTHRANGE = 4103;
+        public const int MCM_GETTODAY = 4109;
+        public const int MCM_HITTEST = 4110;
+        public const int MCM_SETCOLOR = 4106;
+        public const int MCM_SETFIRSTDAYOFWEEK = 4111;
+        public const int MCM_SETMAXSELCOUNT = 4100;
+        public const int MCM_SETMONTHDELTA = 4116;
+        public const int MCM_SETRANGE = 4114;
+        public const int MCM_SETSELRANGE = 4102;
+        public const int MCM_SETTODAY = 4108;
+        public const int MCN_GETDAYSTATE = -747;
+        public const int MCN_SELCHANGE = -749;
+        public const int MCN_SELECT = -746;
+        public const int MCS_DAYSTATE = 1;
+        public const int MCS_MULTISELECT = 2;
+        public const int MCS_NOTODAY = 16;
+        public const int MCS_NOTODAYCIRCLE = 8;
+        public const int MCS_WEEKNUMBERS = 4;
+        public const int MCSC_MONTHBK = 4;
+        public const int MCSC_TEXT = 1;
+        public const int MCSC_TITLEBK = 2;
+        public const int MCSC_TITLETEXT = 3;
+        public const int MCSC_TRAILINGTEXT = 5;
+        public const int MDITILE_HORIZONTAL = 1;
+        public const int MDITILE_VERTICAL = 0;
+        public const int MEMBERID_NIL = -1;
+        public const int MF_BYCOMMAND = 0;
+        public const int MF_BYPOSITION = 1024;
+        public const int MF_ENABLED = 0;
+        public const int MF_GRAYED = 1;
+        public const int MF_POPUP = 16;
+        public const int MF_SYSMENU = 8192;
+        public const int MFT_MENUBREAK = 64;
+        public const int MFT_RIGHTJUSTIFY = 16384;
+        public const int MFT_RIGHTORDER = 8192;
+        public const int MFT_SEPARATOR = 2048;
+        public const int MIIM_DATA = 32;
+        public const int MIIM_ID = 2;
+        public const int MIIM_STATE = 1;
+        public const int MIIM_SUBMENU = 4;
+        public const int MIIM_TYPE = 16;
+        public const int MK_CONTROL = 8;
+        public const int MK_LBUTTON = 1;
+        public const int MK_MBUTTON = 16;
+        public const int MK_RBUTTON = 2;
+        public const int MK_SHIFT = 4;
+        public const int MM_ANISOTROPIC = 8;
+        public const int MM_TEXT = 1;
+        public const int MMIO_ALLOCBUF = 65536;
+        public const int MMIO_FINDRIFF = 32;
+        public const int MMIO_READ = 0;
+        public const int MNC_EXECUTE = 2;
+        public const int MNC_SELECT = 3;
+        public const int MONITOR_OFF = 2;
+        public const int MONITOR_ON = -1;
+        public const int MSAA_MENU_SIG = -1441927155;
+        public const int NFR_ANSI = 1;
+        public const int NFR_UNICODE = 2;
+        public const int NIF_ICON = 2;
+        public const int NIF_INFO = 16;
+        public const int NIF_MESSAGE = 1;
+        public const int NIF_TIP = 4;
+        public const int NIM_ADD = 0;
+        public const int NIM_DELETE = 2;
+        public const int NIM_MODIFY = 1;
+        public const int NIN_BALLOONHIDE = 1027;
+        public const int NIN_BALLOONSHOW = 1026;
+        public const int NIN_BALLOONTIMEOUT = 1028;
+        public const int NIN_BALLOONUSERCLICK = 1029;
+        public const int NM_CLICK = -2;
+        public const int NM_CUSTOMDRAW = -12;
+        public const int NM_DBLCLK = -3;
+        public const int NM_RCLICK = -5;
+        public const int NM_RDBLCLK = -6;
+        public const int NM_RELEASEDCAPTURE = -16;
+        public const int OBJ_BITMAP = 7;
+        public const int OBJ_BRUSH = 2;
+        public const int OBJ_DC = 3;
+        public const int OBJ_ENHMETADC = 12;
+        public const int OBJ_EXTPEN = 11;
+        public const int OBJ_FONT = 6;
+        public const int OBJ_MEMDC = 10;
+        public const int OBJ_METADC = 4;
+        public const int OBJ_METAFILE = 9;
+        public const int OBJ_PAL = 5;
+        public const int OBJ_PEN = 1;
+        public const int OBJ_REGION = 8;
+        public const int ODS_CHECKED = 8;
+        public const int ODS_COMBOBOXEDIT = 4096;
+        public const int ODS_DEFAULT = 32;
+        public const int ODS_DISABLED = 4;
+        public const int ODS_FOCUS = 16;
+        public const int ODS_GRAYED = 2;
+        public const int ODS_HOTLIGHT = 64;
+        public const int ODS_INACTIVE = 128;
+        public const int ODS_NOACCEL = 256;
+        public const int ODS_NOFOCUSRECT = 512;
+        public const int ODS_SELECTED = 1;
+        public const int OFN_ALLOWMULTISELECT = 512;
+        public const int OFN_CREATEPROMPT = 8192;
+        public const int OFN_ENABLEHOOK = 32;
+        public const int OFN_ENABLESIZING = 8388608;
+        public const int OFN_EXPLORER = 524288;
+        public const int OFN_FILEMUSTEXIST = 4096;
+        public const int OFN_HIDEREADONLY = 4;
+        public const int OFN_NOCHANGEDIR = 8;
+        public const int OFN_NODEREFERENCELINKS = 1048576;
+        public const int OFN_NOVALIDATE = 256;
+        public const int OFN_OVERWRITEPROMPT = 2;
+        public const int OFN_PATHMUSTEXIST = 2048;
+        public const int OFN_READONLY = 1;
+        public const int OFN_SHOWHELP = 16;
+        public const int OFN_USESHELLITEM = 16777216;
+        public const int OLE_E_NOCONNECTION = -2147221500;
+        public const int OLE_E_PROMPTSAVECANCELLED = -2147221492;
+        public const int OLECLOSE_PROMPTSAVE = 2;
+        public const int OLECLOSE_SAVEIFDIRTY = 0;
+        public const int OLEIVERB_DISCARDUNDOSTATE = -6;
+        public const int OLEIVERB_HIDE = -3;
+        public const int OLEIVERB_INPLACEACTIVATE = -5;
+        public const int OLEIVERB_PRIMARY = 0;
+        public const int OLEIVERB_PROPERTIES = -7;
+        public const int OLEIVERB_SHOW = -1;
+        public const int OLEIVERB_UIACTIVATE = -4;
+        public const int OLEMISC_ACTIVATEWHENVISIBLE = 256;
+        public const int OLEMISC_ACTSLIKEBUTTON = 4096;
+        public const int OLEMISC_INSIDEOUT = 128;
+        public const int OLEMISC_RECOMPOSEONRESIZE = 1;
+        public const int OLEMISC_SETCLIENTSITEFIRST = 131072;
+        public const int PATCOPY = 15728673;
+        public const int PATINVERT = 5898313;
+        public const int PBM_SETBARCOLOR = 1033;
+        public const int PBM_SETBKCOLOR = 8193;
+        public const int PBM_SETPOS = 1026;
+        public const int PBM_SETRANGE = 1025;
+        public const int PBM_SETRANGE32 = 1030;
+        public const int PBM_SETSTEP = 1028;
+        public const int PBS_SMOOTH = 1;
+        public const int PD_COLLATE = 16;
+        public const int PD_DISABLEPRINTTOFILE = 524288;
+        public const int PD_ENABLEPRINTHOOK = 4096;
+        public const int PD_NOCURRENTPAGE = 8388608;
+        public const int PD_NONETWORKBUTTON = 2097152;
+        public const int PD_NOPAGENUMS = 8;
+        public const int PD_NOSELECTION = 4;
+        public const int PD_PRINTTOFILE = 32;
+        public const int PD_SHOWHELP = 2048;
+        public const int PDERR_CREATEICFAILURE = 4106;
+        public const int PDERR_DEFAULTDIFFERENT = 4108;
+        public const int PDERR_DNDMMISMATCH = 4105;
+        public const int PDERR_GETDEVMODEFAIL = 4101;
+        public const int PDERR_INITFAILURE = 4102;
+        public const int PDERR_LOADDRVFAILURE = 4100;
+        public const int PDERR_NODEFAULTPRN = 4104;
+        public const int PDERR_NODEVICES = 4103;
+        public const int PDERR_PARSEFAILURE = 4098;
+        public const int PDERR_PRINTERNOTFOUND = 4107;
+        public const int PDERR_RETDEFFAILURE = 4099;
+        public const int PDERR_SETUPFAILURE = 4097;
+        public const int PLANES = 14;
+        public const int PM_NOREMOVE = 0;
+        public const int PM_NOYIELD = 2;
+        public const int PM_REMOVE = 1;
+        public const int PRF_CHECKVISIBLE = 1;
+        public const int PRF_CHILDREN = 16;
+        public const int PRF_CLIENT = 4;
+        public const int PRF_ERASEBKGND = 8;
+        public const int PRF_NONCLIENT = 2;
+        public const int PS_DOT = 2;
+        public const int PS_SOLID = 0;
+        public const int PSD_DISABLEMARGINS = 16;
+        public const int PSD_DISABLEORIENTATION = 256;
+        public const int PSD_DISABLEPAPER = 512;
+        public const int PSD_DISABLEPRINTER = 32;
+        public const int PSD_ENABLEPAGESETUPHOOK = 8192;
+        public const int PSD_INHUNDREDTHSOFMILLIMETERS = 8;
+        public const int PSD_MARGINS = 2;
+        public const int PSD_MINMARGINS = 1;
+        public const int PSD_NONETWORKBUTTON = 2097152;
+        public const int PSD_SHOWHELP = 2048;
+        public const int PSM_SETFINISHTEXTA = 1139;
+        public const int PSM_SETFINISHTEXTW = 1145;
+        public const int PSM_SETTITLEA = 1135;
+        public const int PSM_SETTITLEW = 1144;
+        public const int QS_ALLEVENTS = 191;
+        public const int QS_ALLINPUT = 255;
+        public const int QS_ALLPOSTMESSAGE = 256;
+        public const int QS_HOTKEY = 128;
+        public const int QS_INPUT = 7;
+        public const int QS_KEY = 1;
+        public const int QS_MOUSE = 6;
+        public const int QS_MOUSEBUTTON = 4;
+        public const int QS_MOUSEMOVE = 2;
+        public const int QS_PAINT = 32;
+        public const int QS_POSTMESSAGE = 8;
+        public const int QS_SENDMESSAGE = 64;
+        public const int QS_TIMER = 16;
+        public const int RB_INSERTBANDA = 1025;
+        public const int RB_INSERTBANDW = 1034;
+        public const int RDW_ALLCHILDREN = 128;
+        public const int RDW_ERASE = 4;
+        public const int RDW_FRAME = 1024;
+        public const int RDW_INVALIDATE = 1;
+        public const int RGN_AND = 1;
+        public const int RGN_DIFF = 4;
+        public const int RPC_E_CANTCALLOUT_ININPUTSYNCCALL = -2147417843;
+        public const int RPC_E_CHANGED_MODE = -2147417850;
+        public const int S_FALSE = 1;
+        public const int S_OK = 0;
+        public const int SB_BOTTOM = 7;
+        public const int SB_CTL = 2;
+        public const int SB_ENDSCROLL = 8;
+        public const int SB_GETRECT = 1034;
+        public const int SB_GETTEXTA = 1026;
+        public const int SB_GETTEXTLENGTHA = 1027;
+        public const int SB_GETTEXTLENGTHW = 1036;
+        public const int SB_GETTEXTW = 1037;
+        public const int SB_GETTIPTEXTA = 1042;
+        public const int SB_GETTIPTEXTW = 1043;
+        public const int SB_HORZ = 0;
+        public const int SB_LEFT = 6;
+        public const int SB_LINEDOWN = 1;
+        public const int SB_LINELEFT = 0;
+        public const int SB_LINERIGHT = 1;
+        public const int SB_LINEUP = 0;
+        public const int SB_PAGEDOWN = 3;
+        public const int SB_PAGELEFT = 2;
+        public const int SB_PAGERIGHT = 3;
+        public const int SB_PAGEUP = 2;
+        public const int SB_RIGHT = 7;
+        public const int SB_SETICON = 1039;
+        public const int SB_SETPARTS = 1028;
+        public const int SB_SETTEXTA = 1025;
+        public const int SB_SETTEXTW = 1035;
+        public const int SB_SETTIPTEXTA = 1040;
+        public const int SB_SETTIPTEXTW = 1041;
+        public const int SB_SIMPLE = 1033;
+        public const int SB_THUMBPOSITION = 4;
+        public const int SB_THUMBTRACK = 5;
+        public const int SB_TOP = 6;
+        public const int SB_VERT = 1;
+        public const int SBARS_SIZEGRIP = 256;
+        public const int SBS_HORZ = 0;
+        public const int SBS_VERT = 1;
+        public const int SBT_NOBORDERS = 256;
+        public const int SBT_OWNERDRAW = 4096;
+        public const int SBT_POPOUT = 512;
+        public const int SBT_RTLREADING = 1024;
+        public const int SC_CLOSE = 61536;
+        public const int SC_KEYMENU = 61696;
+        public const int SC_MAXIMIZE = 61488;
+        public const int SC_MINIMIZE = 61472;
+        public const int SC_MONITORPOWER = 61808;
+        public const int SC_MOVE = 61456;
+        public const int SC_RESTORE = 61728;
+        public const int SC_SIZE = 61440;
+        public const uint SHACF_AUTOAPPEND_FORCE_OFF = 2147483648u;
+        public const uint SHACF_AUTOAPPEND_FORCE_ON = 1073741824u;
+        public const uint SHACF_AUTOSUGGEST_FORCE_OFF = 536870912u;
+        public const uint SHACF_AUTOSUGGEST_FORCE_ON = 268435456u;
+        public const uint SHACF_DEFAULT = 0u;
+        public const uint SHACF_FILESYS_DIRS = 32u;
+        public const uint SHACF_FILESYS_ONLY = 16u;
+        public const uint SHACF_FILESYSTEM = 1u;
+        public const uint SHACF_URLALL = 6u;
+        public const uint SHACF_URLHISTORY = 2u;
+        public const uint SHACF_URLMRU = 4u;
+        public const uint SHACF_USETAB = 8u;
+        public const int SHGFI_ADDOVERLAYS = 32;
+        public const int SHGFI_ATTR_SPECIFIED = 131072;
+        public const int SHGFI_ATTRIBUTES = 2048;
+        public const int SHGFI_DISPLAYNAME = 512;
+        public const int SHGFI_EXETYPE = 8192;
+        public const int SHGFI_ICON = 256;
+        public const int SHGFI_ICONLOCATION = 4096;
+        public const int SHGFI_LARGEICON = 0;
+        public const int SHGFI_LINKOVERLAY = 32768;
+        public const int SHGFI_OPENICON = 2;
+        public const int SHGFI_OVERLAYINDEX = 64;
+        public const int SHGFI_PIDL = 8;
+        public const int SHGFI_SELECTED = 65536;
+        public const int SHGFI_SHELLICONSIZE = 4;
+        public const int SHGFI_SMALLICON = 1;
+        public const int SHGFI_SYSICONINDEX = 16384;
+        public const int SHGFI_TYPENAME = 1024;
+        public const int SHGFI_USEFILEATTRIBUTES = 16;
+        public const int SHGFP_TYPE_CURRENT = 0;
+        public const int SIF_ALL = 23;
+        public const int SIF_PAGE = 2;
+        public const int SIF_POS = 4;
+        public const int SIF_RANGE = 1;
+        public const int SIF_TRACKPOS = 16;
+        public const int SM_ARRANGE = 56;
+        public const int SM_CLEANBOOT = 67;
+        public const int SM_CMONITORS = 80;
+        public const int SM_CMOUSEBUTTONS = 43;
+        public const int SM_CXBORDER = 5;
+        public const int SM_CXCURSOR = 13;
+        public const int SM_CXDOUBLECLK = 36;
+        public const int SM_CXDRAG = 68;
+        public const int SM_CXEDGE = 45;
+        public const int SM_CXFIXEDFRAME = 7;
+        public const int SM_CXFOCUSBORDER = 83;
+        public const int SM_CXFRAME = 32;
+        public const int SM_CXHSCROLL = 21;
+        public const int SM_CXHTHUMB = 10;
+        public const int SM_CXICON = 11;
+        public const int SM_CXICONSPACING = 38;
+        public const int SM_CXMAXIMIZED = 61;
+        public const int SM_CXMAXTRACK = 59;
+        public const int SM_CXMENUCHECK = 71;
+        public const int SM_CXMENUSIZE = 54;
+        public const int SM_CXMIN = 28;
+        public const int SM_CXMINIMIZED = 57;
+        public const int SM_CXMINSPACING = 47;
+        public const int SM_CXMINTRACK = 34;
+        public const int SM_CXSCREEN = 0;
+        public const int SM_CXSIZE = 30;
+        public const int SM_CXSIZEFRAME = 32;
+        public const int SM_CXSMICON = 49;
+        public const int SM_CXSMSIZE = 52;
+        public const int SM_CXVIRTUALSCREEN = 78;
+        public const int SM_CXVSCROLL = 2;
+        public const int SM_CYBORDER = 6;
+        public const int SM_CYCAPTION = 4;
+        public const int SM_CYCURSOR = 14;
+        public const int SM_CYDOUBLECLK = 37;
+        public const int SM_CYDRAG = 69;
+        public const int SM_CYEDGE = 46;
+        public const int SM_CYFIXEDFRAME = 8;
+        public const int SM_CYFOCUSBORDER = 84;
+        public const int SM_CYFRAME = 33;
+        public const int SM_CYHSCROLL = 3;
+        public const int SM_CYICON = 12;
+        public const int SM_CYICONSPACING = 39;
+        public const int SM_CYKANJIWINDOW = 18;
+        public const int SM_CYMAXIMIZED = 62;
+        public const int SM_CYMAXTRACK = 60;
+        public const int SM_CYMENU = 15;
+        public const int SM_CYMENUCHECK = 72;
+        public const int SM_CYMENUSIZE = 55;
+        public const int SM_CYMIN = 29;
+        public const int SM_CYMINIMIZED = 58;
+        public const int SM_CYMINSPACING = 48;
+        public const int SM_CYMINTRACK = 35;
+        public const int SM_CYSCREEN = 1;
+        public const int SM_CYSIZE = 31;
+        public const int SM_CYSIZEFRAME = 33;
+        public const int SM_CYSMCAPTION = 51;
+        public const int SM_CYSMICON = 50;
+        public const int SM_CYSMSIZE = 53;
+        public const int SM_CYVIRTUALSCREEN = 79;
+        public const int SM_CYVSCROLL = 20;
+        public const int SM_CYVTHUMB = 9;
+        public const int SM_DBCSENABLED = 42;
+        public const int SM_DEBUG = 22;
+        public const int SM_MENUDROPALIGNMENT = 40;
+        public const int SM_MIDEASTENABLED = 74;
+        public const int SM_MOUSEPRESENT = 19;
+        public const int SM_MOUSEWHEELPRESENT = 75;
+        public const int SM_NETWORK = 63;
+        public const int SM_PENWINDOWS = 41;
+        public const int SM_REMOTESESSION = 4096;
+        public const int SM_SAMEDISPLAYFORMAT = 81;
+        public const int SM_SECURE = 44;
+        public const int SM_SHOWSOUNDS = 70;
+        public const int SM_SWAPBUTTON = 23;
+        public const int SM_XVIRTUALSCREEN = 76;
+        public const int SM_YVIRTUALSCREEN = 77;
+        public const int SND_ASYNC = 1;
+        public const int SND_FILENAME = 131072;
+        public const int SND_LOOP = 8;
+        public const int SND_MEMORY = 4;
+        public const int SND_NODEFAULT = 2;
+        public const int SND_NOSTOP = 16;
+        public const int SND_PURGE = 64;
+        public const int SND_SYNC = 0;
+        public const int SORT_DEFAULT = 0;
+        public const int SPI_GETACTIVEWINDOWTRACKING = 4096;
+        public const int SPI_GETACTIVEWNDTRKTIMEOUT = 8194;
+        public const int SPI_GETANIMATION = 72;
+        public const int SPI_GETBORDER = 5;
+        public const int SPI_GETCARETWIDTH = 8198;
+        public const int SPI_GETCOMBOBOXANIMATION = 4100;
+        public const int SPI_GETDEFAULTINPUTLANG = 89;
+        public const int SPI_GETDRAGFULLWINDOWS = 38;
+        public const int SPI_GETDROPSHADOW = 4132;
+        public const int SPI_GETFLATMENU = 4130;
+        public const int SPI_GETFONTSMOOTHING = 74;
+        public const int SPI_GETFONTSMOOTHINGCONTRAST = 8204;
+        public const int SPI_GETFONTSMOOTHINGTYPE = 8202;
+        public const int SPI_GETGRADIENTCAPTIONS = 4104;
+        public const int SPI_GETHIGHCONTRAST = 66;
+        public const int SPI_GETHOTTRACKING = 4110;
+        public const int SPI_GETICONTITLELOGFONT = 31;
+        public const int SPI_GETICONTITLEWRAP = 25;
+        public const int SPI_GETKEYBOARDCUES = 4106;
+        public const int SPI_GETKEYBOARDDELAY = 22;
+        public const int SPI_GETKEYBOARDPREF = 68;
+        public const int SPI_GETKEYBOARDSPEED = 10;
+        public const int SPI_GETLISTBOXSMOOTHSCROLLING = 4102;
+        public const int SPI_GETMENUANIMATION = 4098;
+        public const int SPI_GETMENUDROPALIGNMENT = 27;
+        public const int SPI_GETMENUFADE = 4114;
+        public const int SPI_GETMENUSHOWDELAY = 106;
+        public const int SPI_GETMOUSEHOVERHEIGHT = 100;
+        public const int SPI_GETMOUSEHOVERTIME = 102;
+        public const int SPI_GETMOUSEHOVERWIDTH = 98;
+        public const int SPI_GETMOUSESPEED = 112;
+        public const int SPI_GETNONCLIENTMETRICS = 41;
+        public const int SPI_GETSELECTIONFADE = 4116;
+        public const int SPI_GETSNAPTODEFBUTTON = 95;
+        public const int SPI_GETTOOLTIPANIMATION = 4118;
+        public const int SPI_GETUIEFFECTS = 4158;
+        public const int SPI_GETWHEELSCROLLLINES = 104;
+        public const int SPI_GETWORKAREA = 48;
+        public const int SPI_ICONHORIZONTALSPACING = 13;
+        public const int SPI_ICONVERTICALSPACING = 24;
+        public const int SRCCOPY = 13369376;
+        public const int SS_CENTER = 1;
+        public const int SS_LEFT = 0;
+        public const int SS_NOPREFIX = 128;
+        public const int SS_OWNERDRAW = 13;
+        public const int SS_RIGHT = 2;
+        public const int SS_SUNKEN = 4096;
+        public const int STARTF_USESHOWWINDOW = 1;
+        public const int STATFLAG_DEFAULT = 0;
+        public const int STATFLAG_NONAME = 1;
+        public const int STATFLAG_NOOPEN = 2;
+        public const int stc4 = 1091;
+        public const int STG_E_ACCESSDENIED = -2147287035;
+        public const int STG_E_DISKISWRITEPROTECTED = -2147287021;
+        public const int STG_E_FILENOTFOUND = -2147287038;
+        public const int STG_E_INSUFFICIENTMEMORY = -2147287032;
+        public const int STG_E_INVALIDFUNCTION = -2147287039;
+        public const int STG_E_INVALIDHANDLE = -2147287034;
+        public const int STG_E_INVALIDPOINTER = -2147287031;
+        public const int STG_E_LOCKVIOLATION = -2147287007;
+        public const int STG_E_NOMOREFILES = -2147287022;
+        public const int STG_E_PATHNOTFOUND = -2147287037;
+        public const int STG_E_READFAULT = -2147287010;
+        public const int STG_E_SEEKERROR = -2147287015;
+        public const int STG_E_SHAREVIOLATION = -2147287008;
+        public const int STG_E_TOOMANYOPENFILES = -2147287036;
+        public const int STG_E_WRITEFAULT = -2147287011;
+        public const int STGC_DANGEROUSLYCOMMITMERELYTODISKCACHE = 4;
+        public const int STGC_DEFAULT = 0;
+        public const int STGC_ONLYIFCURRENT = 2;
+        public const int STGC_OVERWRITE = 1;
+        public const int STGM_CONVERT = 131072;
+        public const int STGM_CREATE = 4096;
+        public const int STGM_DELETEONRELEASE = 67108864;
+        public const int STGM_READ = 0;
+        public const int STGM_READWRITE = 2;
+        public const int STGM_SHARE_EXCLUSIVE = 16;
+        public const int STGM_TRANSACTED = 65536;
+        public const int STGM_WRITE = 1;
+        public const int STREAM_SEEK_CUR = 1;
+        public const int STREAM_SEEK_END = 2;
+        public const int STREAM_SEEK_SET = 0;
+        public const int SUBLANG_DEFAULT = 1;
+        public const int SW_ERASE = 4;
+        public const int SW_HIDE = 0;
+        public const int SW_INVALIDATE = 2;
+        public const int SW_MAX = 10;
+        public const int SW_MAXIMIZE = 3;
+        public const int SW_MINIMIZE = 6;
+        public const int SW_NORMAL = 1;
+        public const int SW_RESTORE = 9;
+        public const int SW_SCROLLCHILDREN = 1;
+        public const int SW_SHOW = 5;
+        public const int SW_SHOWMAXIMIZED = 3;
+        public const int SW_SHOWMINIMIZED = 2;
+        public const int SW_SHOWMINNOACTIVE = 7;
+        public const int SW_SHOWNA = 8;
+        public const int SW_SHOWNOACTIVATE = 4;
+        public const int SW_SMOOTHSCROLL = 16;
+        public const int SWP_DRAWFRAME = 32;
+        public const int SWP_HIDEWINDOW = 128;
+        public const int SWP_NOACTIVATE = 16;
+        public const int SWP_NOMOVE = 2;
+        public const int SWP_NOSIZE = 1;
+        public const int SWP_NOZORDER = 4;
+        public const int SWP_SHOWWINDOW = 64;
+        public const int TB_ADDBUTTONSA = 1044;
+        public const int TB_ADDBUTTONSW = 1092;
+        public const int TB_ADDSTRINGA = 1052;
+        public const int TB_ADDSTRINGW = 1101;
+        public const int TB_AUTOSIZE = 1057;
+        public const int TB_BOTTOM = 7;
+        public const int TB_BUTTONSTRUCTSIZE = 1054;
+        public const int TB_DELETEBUTTON = 1046;
+        public const int TB_ENABLEBUTTON = 1025;
+        public const int TB_ENDTRACK = 8;
+        public const int TB_GETBUTTON = 1047;
+        public const int TB_GETBUTTONINFOA = 1089;
+        public const int TB_GETBUTTONINFOW = 1087;
+        public const int TB_GETBUTTONSIZE = 1082;
+        public const int TB_GETBUTTONTEXTA = 1069;
+        public const int TB_GETBUTTONTEXTW = 1099;
+        public const int TB_GETRECT = 1075;
+        public const int TB_GETROWS = 1064;
+        public const int TB_INSERTBUTTONA = 1045;
+        public const int TB_INSERTBUTTONW = 1091;
+        public const int TB_ISBUTTONCHECKED = 1034;
+        public const int TB_ISBUTTONINDETERMINATE = 1037;
+        public const int TB_LINEDOWN = 1;
+        public const int TB_LINEUP = 0;
+        public const int TB_MAPACCELERATORA = 1102;
+        public const int TB_MAPACCELERATORW = 1114;
+        public const int TB_PAGEDOWN = 3;
+        public const int TB_PAGEUP = 2;
+        public const int TB_SAVERESTOREA = 1050;
+        public const int TB_SAVERESTOREW = 1100;
+        public const int TB_SETBUTTONINFOA = 1090;
+        public const int TB_SETBUTTONINFOW = 1088;
+        public const int TB_SETBUTTONSIZE = 1055;
+        public const int TB_SETEXTENDEDSTYLE = 1108;
+        public const int TB_SETIMAGELIST = 1072;
+        public const int TB_SETTOOLTIPS = 1060;
+        public const int TB_THUMBPOSITION = 4;
+        public const int TB_THUMBTRACK = 5;
+        public const int TB_TOP = 6;
+        public const int TBIF_COMMAND = 32;
+        public const int TBIF_IMAGE = 1;
+        public const int TBIF_SIZE = 64;
+        public const int TBIF_STATE = 4;
+        public const int TBIF_STYLE = 8;
+        public const int TBIF_TEXT = 2;
+        public const int TBM_GETPOS = 1024;
+        public const int TBM_SETLINESIZE = 1047;
+        public const int TBM_SETPAGESIZE = 1045;
+        public const int TBM_SETPOS = 1029;
+        public const int TBM_SETRANGE = 1030;
+        public const int TBM_SETRANGEMAX = 1032;
+        public const int TBM_SETRANGEMIN = 1031;
+        public const int TBM_SETTIC = 1028;
+        public const int TBM_SETTICFREQ = 1044;
+        public const int TBN_DROPDOWN = -710;
+        public const int TBN_GETBUTTONINFOA = -700;
+        public const int TBN_GETBUTTONINFOW = -720;
+        public const int TBN_GETDISPINFOA = -716;
+        public const int TBN_GETDISPINFOW = -717;
+        public const int TBN_GETINFOTIPA = -718;
+        public const int TBN_GETINFOTIPW = -719;
+        public const int TBN_QUERYINSERT = -706;
+        public const int TBS_AUTOTICKS = 1;
+        public const int TBS_BOTH = 8;
+        public const int TBS_BOTTOM = 0;
+        public const int TBS_NOTICKS = 16;
+        public const int TBS_TOP = 4;
+        public const int TBS_VERT = 2;
+        public const int TBSTATE_CHECKED = 1;
+        public const int TBSTATE_ENABLED = 4;
+        public const int TBSTATE_HIDDEN = 8;
+        public const int TBSTATE_INDETERMINATE = 16;
+        public const int TBSTYLE_BUTTON = 0;
+        public const int TBSTYLE_CHECK = 2;
+        public const int TBSTYLE_DROPDOWN = 8;
+        public const int TBSTYLE_EX_DRAWDDARROWS = 1;
+        public const int TBSTYLE_FLAT = 2048;
+        public const int TBSTYLE_LIST = 4096;
+        public const int TBSTYLE_SEP = 1;
+        public const int TBSTYLE_TOOLTIPS = 256;
+        public const int TBSTYLE_WRAPPABLE = 512;
+        public const int TCIF_IMAGE = 2;
+        public const int TCIF_TEXT = 1;
+        public const int TCM_ADJUSTRECT = 4904;
+        public const int TCM_DELETEALLITEMS = 4873;
+        public const int TCM_DELETEITEM = 4872;
+        public const int TCM_GETCURSEL = 4875;
+        public const int TCM_GETITEMA = 4869;
+        public const int TCM_GETITEMRECT = 4874;
+        public const int TCM_GETITEMW = 4924;
+        public const int TCM_GETROWCOUNT = 4908;
+        public const int TCM_GETTOOLTIPS = 4909;
+        public const int TCM_INSERTITEMA = 4871;
+        public const int TCM_INSERTITEMW = 4926;
+        public const int TCM_SETCURSEL = 4876;
+        public const int TCM_SETIMAGELIST = 4867;
+        public const int TCM_SETITEMA = 4870;
+        public const int TCM_SETITEMSIZE = 4905;
+        public const int TCM_SETITEMW = 4925;
+        public const int TCM_SETPADDING = 4907;
+        public const int TCM_SETTOOLTIPS = 4910;
+        public const int TCN_SELCHANGE = -551;
+        public const int TCN_SELCHANGING = -552;
+        public const int TCS_BOTTOM = 2;
+        public const int TCS_BUTTONS = 256;
+        public const int TCS_FIXEDWIDTH = 1024;
+        public const int TCS_FLATBUTTONS = 8;
+        public const int TCS_HOTTRACK = 64;
+        public const int TCS_MULTILINE = 512;
+        public const int TCS_OWNERDRAWFIXED = 8192;
+        public const int TCS_RAGGEDRIGHT = 2048;
+        public const int TCS_RIGHT = 2;
+        public const int TCS_RIGHTJUSTIFY = 0;
+        public const int TCS_TABS = 0;
+        public const int TCS_TOOLTIPS = 16384;
+        public const int TCS_VERTICAL = 128;
+        public const int TME_HOVER = 1;
+        public const int TME_LEAVE = 2;
+        public const int TPM_LEFTALIGN = 0;
+        public const int TPM_LEFTBUTTON = 0;
+        public const int TPM_VERTICAL = 64;
+        public const int TRANSPARENT = 1;
+        public const int TTDT_AUTOMATIC = 0;
+        public const int TTDT_AUTOPOP = 2;
+        public const int TTDT_INITIAL = 3;
+        public const int TTDT_RESHOW = 1;
+        public const int TTF_ABSOLUTE = 128;
+        public const int TTF_CENTERTIP = 2;
+        public const int TTF_IDISHWND = 1;
+        public const int TTF_RTLREADING = 4;
+        public const int TTF_SUBCLASS = 16;
+        public const int TTF_TRACK = 32;
+        public const int TTF_TRANSPARENT = 256;
+        public const int TTI_WARNING = 2;
+        public const int TTM_ACTIVATE = 1025;
+        public const int TTM_ADDTOOLA = 1028;
+        public const int TTM_ADDTOOLW = 1074;
+        public const int TTM_ADJUSTRECT = 1055;
+        public const int TTM_DELTOOLA = 1029;
+        public const int TTM_DELTOOLW = 1075;
+        public const int TTM_ENUMTOOLSA = 1038;
+        public const int TTM_ENUMTOOLSW = 1082;
+        public const int TTM_GETCURRENTTOOLA = 1039;
+        public const int TTM_GETCURRENTTOOLW = 1083;
+        public const int TTM_GETDELAYTIME = 1045;
+        public const int TTM_GETTEXTA = 1035;
+        public const int TTM_GETTEXTW = 1080;
+        public const int TTM_GETTIPBKCOLOR = 1046;
+        public const int TTM_GETTIPTEXTCOLOR = 1047;
+        public const int TTM_GETTOOLINFOA = 1032;
+        public const int TTM_GETTOOLINFOW = 1077;
+        public const int TTM_HITTESTA = 1034;
+        public const int TTM_HITTESTW = 1079;
+        public const int TTM_NEWTOOLRECTA = 1030;
+        public const int TTM_NEWTOOLRECTW = 1076;
+        public const int TTM_POP = 1052;
+        public const int TTM_RELAYEVENT = 1031;
+        public const int TTM_SETDELAYTIME = 1027;
+        public const int TTM_SETMAXTIPWIDTH = 1048;
+        public const int TTM_SETTIPBKCOLOR = 1043;
+        public const int TTM_SETTIPTEXTCOLOR = 1044;
+        public const int TTM_SETTITLEA = 1056;
+        public const int TTM_SETTITLEW = 1057;
+        public const int TTM_SETTOOLINFOA = 1033;
+        public const int TTM_SETTOOLINFOW = 1078;
+        public const int TTM_TRACKACTIVATE = 1041;
+        public const int TTM_TRACKPOSITION = 1042;
+        public const int TTM_UPDATE = 1053;
+        public const int TTM_UPDATETIPTEXTA = 1036;
+        public const int TTM_UPDATETIPTEXTW = 1081;
+        public const int TTM_WINDOWFROMPOINT = 1040;
+        public const int TTN_GETDISPINFOA = -520;
+        public const int TTN_GETDISPINFOW = -530;
+        public const int TTN_NEEDTEXTA = -520;
+        public const int TTN_NEEDTEXTW = -530;
+        public const int TTN_POP = -522;
+        public const int TTN_SHOW = -521;
+        public const int TTS_ALWAYSTIP = 1;
+        public const int TTS_BALLOON = 64;
+        public const int TTS_NOANIMATE = 16;
+        public const int TTS_NOFADE = 32;
+        public const int TTS_NOPREFIX = 2;
+        public const int TV_FIRST = 4352;
+        public const int TVC_BYKEYBOARD = 2;
+        public const int TVC_BYMOUSE = 1;
+        public const int TVC_UNKNOWN = 0;
+        public const int TVE_COLLAPSE = 1;
+        public const int TVE_EXPAND = 2;
+        public const int TVGN_CARET = 9;
+        public const int TVGN_FIRSTVISIBLE = 5;
+        public const int TVGN_NEXT = 1;
+        public const int TVGN_NEXTVISIBLE = 6;
+        public const int TVGN_PREVIOUS = 2;
+        public const int TVGN_PREVIOUSVISIBLE = 7;
+        public const int TVHT_ABOVE = 256;
+        public const int TVHT_BELOW = 512;
+        public const int TVHT_NOWHERE = 1;
+        public const int TVHT_ONITEM = 70;
+        public const int TVHT_ONITEMBUTTON = 16;
+        public const int TVHT_ONITEMICON = 2;
+        public const int TVHT_ONITEMINDENT = 8;
+        public const int TVHT_ONITEMLABEL = 4;
+        public const int TVHT_ONITEMRIGHT = 32;
+        public const int TVHT_ONITEMSTATEICON = 64;
+        public const int TVHT_TOLEFT = 2048;
+        public const int TVHT_TORIGHT = 1024;
+        public const int TVI_FIRST = -65535;
+        public const int TVI_ROOT = -65536;
+        public const int TVIF_HANDLE = 16;
+        public const int TVIF_IMAGE = 2;
+        public const int TVIF_PARAM = 4;
+        public const int TVIF_SELECTEDIMAGE = 32;
+        public const int TVIF_STATE = 8;
+        public const int TVIF_TEXT = 1;
+        public const int TVIS_EXPANDED = 32;
+        public const int TVIS_EXPANDEDONCE = 64;
+        public const int TVIS_SELECTED = 2;
+        public const int TVIS_STATEIMAGEMASK = 61440;
+        public const int TVM_DELETEITEM = 4353;
+        public const int TVM_EDITLABELA = 4366;
+        public const int TVM_EDITLABELW = 4417;
+        public const int TVM_ENDEDITLABELNOW = 4374;
+        public const int TVM_ENSUREVISIBLE = 4372;
+        public const int TVM_EXPAND = 4354;
+        public const int TVM_GETEDITCONTROL = 4367;
+        public const int TVM_GETINDENT = 4358;
+        public const int TVM_GETISEARCHSTRINGA = 4375;
+        public const int TVM_GETISEARCHSTRINGW = 4416;
+        public const int TVM_GETITEMA = 4364;
+        public const int TVM_GETITEMHEIGHT = 4380;
+        public const int TVM_GETITEMRECT = 4356;
+        public const int TVM_GETITEMW = 4414;
+        public const int TVM_GETLINECOLOR = 4393;
+        public const int TVM_GETNEXTITEM = 4362;
+        public const int TVM_GETVISIBLECOUNT = 4368;
+        public const int TVM_HITTEST = 4369;
+        public const int TVM_INSERTITEMA = 4352;
+        public const int TVM_INSERTITEMW = 4402;
+        public const int TVM_SELECTITEM = 4363;
+        public const int TVM_SETBKCOLOR = 4381;
+        public const int TVM_SETIMAGELIST = 4361;
+        public const int TVM_SETINDENT = 4359;
+        public const int TVM_SETITEMA = 4365;
+        public const int TVM_SETITEMHEIGHT = 4379;
+        public const int TVM_SETITEMW = 4415;
+        public const int TVM_SETLINECOLOR = 4392;
+        public const int TVM_SETTEXTCOLOR = 4382;
+        public const int TVM_SETTOOLTIPS = 4376;
+        public const int TVM_SORTCHILDRENCB = 4373;
+        public const int TVN_BEGINDRAGA = -407;
+        public const int TVN_BEGINDRAGW = -456;
+        public const int TVN_BEGINLABELEDITA = -410;
+        public const int TVN_BEGINLABELEDITW = -459;
+        public const int TVN_BEGINRDRAGA = -408;
+        public const int TVN_BEGINRDRAGW = -457;
+        public const int TVN_ENDLABELEDITA = -411;
+        public const int TVN_ENDLABELEDITW = -460;
+        public const int TVN_GETDISPINFOA = -403;
+        public const int TVN_GETDISPINFOW = -452;
+        public const int TVN_GETINFOTIPA = -413;
+        public const int TVN_GETINFOTIPW = -414;
+        public const int TVN_ITEMEXPANDEDA = -406;
+        public const int TVN_ITEMEXPANDEDW = -455;
+        public const int TVN_ITEMEXPANDINGA = -405;
+        public const int TVN_ITEMEXPANDINGW = -454;
+        public const int TVN_SELCHANGEDA = -402;
+        public const int TVN_SELCHANGEDW = -451;
+        public const int TVN_SELCHANGINGA = -401;
+        public const int TVN_SELCHANGINGW = -450;
+        public const int TVN_SETDISPINFOA = -404;
+        public const int TVN_SETDISPINFOW = -453;
+        public const int TVS_CHECKBOXES = 256;
+        public const int TVS_EDITLABELS = 8;
+        public const int TVS_FULLROWSELECT = 4096;
+        public const int TVS_HASBUTTONS = 1;
+        public const int TVS_HASLINES = 2;
+        public const int TVS_INFOTIP = 2048;
+        public const int TVS_LINESATROOT = 4;
+        public const int TVS_NOTOOLTIPS = 128;
+        public const int TVS_RTLREADING = 64;
+        public const int TVS_SHOWSELALWAYS = 32;
+        public const int TVS_TRACKSELECT = 512;
+        public const int TVSIL_STATE = 2;
+        public const int TYMED_NULL = 0;
+        public const int UIS_CLEAR = 2;
+        public const int UIS_INITIALIZE = 3;
+        public const int UIS_SET = 1;
+        public const int UISF_HIDEACCEL = 2;
+        public const int UISF_HIDEFOCUS = 1;
+        public const int UOI_FLAGS = 1;
+        public const int USERCLASSTYPE_APPNAME = 3;
+        public const int USERCLASSTYPE_FULL = 1;
+        public const int USERCLASSTYPE_SHORT = 2;
+        public const int VIEW_E_DRAW = -2147221184;
+        public const int VK_CAPSLOCK = 20;
+        public const int VK_CONTROL = 17;
+        public const int VK_DOWN = 40;
+        public const int VK_ESCAPE = 27;
+        public const int VK_LEFT = 37;
+        public const int VK_MENU = 18;
+        public const int VK_NUMLOCK = 144;
+        public const int VK_RIGHT = 39;
+        public const int VK_SCROLL = 145;
+        public const int VK_SHIFT = 16;
+        public const int VK_TAB = 9;
+        public const int VK_UP = 38;
+        public const int WA_ACTIVE = 1;
+        public const int WA_CLICKACTIVE = 2;
+        public const int WA_INACTIVE = 0;
+        public const int WAVE_FORMAT_ADPCM = 2;
+        public const int WAVE_FORMAT_IEEE_FLOAT = 3;
+        public const int WAVE_FORMAT_PCM = 1;
+        public const int WH_GETMESSAGE = 3;
+        public const int WH_JOURNALPLAYBACK = 1;
+        public const int WH_KEYBOARD_LL = 13;
+        public const int WH_MOUSE = 7;
+        public const int WHEEL_DELTA = 120;
+        public const int WM_ACTIVATE = 6;
+        public const int WM_ACTIVATEAPP = 28;
+        public const int WM_AFXFIRST = 864;
+        public const int WM_AFXLAST = 895;
+        public const int WM_APP = 32768;
+        public const int WM_ASKCBFORMATNAME = 780;
+        public const int WM_CANCELJOURNAL = 75;
+        public const int WM_CANCELMODE = 31;
+        public const int WM_CAPTURECHANGED = 533;
+        public const int WM_CHANGECBCHAIN = 781;
+        public const int WM_CHANGEUISTATE = 295;
+        public const int WM_CHAR = 258;
+        public const int WM_CHARTOITEM = 47;
+        public const int WM_CHILDACTIVATE = 34;
+        public const int WM_CHOOSEFONT_GETLOGFONT = 1025;
+        public const int WM_CLEAR = 771;
+        public const int WM_CLOSE = 16;
+        public const int WM_COMMAND = 273;
+        public const int WM_COMMNOTIFY = 68;
+        public const int WM_COMPACTING = 65;
+        public const int WM_COMPAREITEM = 57;
+        public const int WM_CONTEXTMENU = 123;
+        public const int WM_COPY = 769;
+        public const int WM_COPYDATA = 74;
+        public const int WM_CREATE = 1;
+        public const int WM_CTLCOLOR = 25;
+        public const int WM_CTLCOLORBTN = 309;
+        public const int WM_CTLCOLORDLG = 310;
+        public const int WM_CTLCOLOREDIT = 307;
+        public const int WM_CTLCOLORLISTBOX = 308;
+        public const int WM_CTLCOLORMSGBOX = 306;
+        public const int WM_CTLCOLORSCROLLBAR = 311;
+        public const int WM_CTLCOLORSTATIC = 312;
+        public const int WM_CUT = 768;
+        public const int WM_DEADCHAR = 259;
+        public const int WM_DELETEITEM = 45;
+        public const int WM_DESTROY = 2;
+        public const int WM_DESTROYCLIPBOARD = 775;
+        public const int WM_DEVICECHANGE = 537;
+        public const int WM_DEVMODECHANGE = 27;
+        public const int WM_DISPLAYCHANGE = 126;
+        public const int WM_DRAWCLIPBOARD = 776;
+        public const int WM_DRAWITEM = 43;
+        public const int WM_DROPFILES = 563;
+        public const int WM_ENABLE = 10;
+        public const int WM_ENDSESSION = 22;
+        public const int WM_ENTERIDLE = 289;
+        public const int WM_ENTERMENULOOP = 529;
+        public const int WM_ENTERSIZEMOVE = 561;
+        public const int WM_ERASEBKGND = 20;
+        public const int WM_EXITMENULOOP = 530;
+        public const int WM_EXITSIZEMOVE = 562;
+        public const int WM_FONTCHANGE = 29;
+        public const int WM_GETDLGCODE = 135;
+        public const int WM_GETFONT = 49;
+        public const int WM_GETHOTKEY = 51;
+        public const int WM_GETICON = 127;
+        public const int WM_GETMINMAXINFO = 36;
+        public const int WM_GETOBJECT = 61;
+        public const int WM_GETTEXT = 13;
+        public const int WM_GETTEXTLENGTH = 14;
+        public const int WM_HANDHELDFIRST = 856;
+        public const int WM_HANDHELDLAST = 863;
+        public const int WM_HELP = 83;
+        public const int WM_HOTKEY = 786;
+        public const int WM_HSCROLL = 276;
+        public const int WM_HSCROLLCLIPBOARD = 782;
+        public const int WM_ICONERASEBKGND = 39;
+        public const int WM_IME_CHAR = 646;
+        public const int WM_IME_COMPOSITION = 271;
+        public const int WM_IME_COMPOSITIONFULL = 644;
+        public const int WM_IME_CONTROL = 643;
+        public const int WM_IME_ENDCOMPOSITION = 270;
+        public const int WM_IME_KEYDOWN = 656;
+        public const int WM_IME_KEYLAST = 271;
+        public const int WM_IME_KEYUP = 657;
+        public const int WM_IME_NOTIFY = 642;
+        public const int WM_IME_SELECT = 645;
+        public const int WM_IME_SETCONTEXT = 641;
+        public const int WM_IME_STARTCOMPOSITION = 269;
+        public const int WM_INITDIALOG = 272;
+        public const int WM_INITMENU = 278;
+        public const int WM_INITMENUPOPUP = 279;
+        public const int WM_INPUTLANGCHANGE = 81;
+        public const int WM_INPUTLANGCHANGEREQUEST = 80;
+        public const int WM_KEYDOWN = 256;
+        public const int WM_KEYFIRST = 256;
+        public const int WM_KEYLAST = 264;
+        public const int WM_KEYUP = 257;
+        public const int WM_KILLFOCUS = 8;
+        public const int WM_LBUTTONDBLCLK = 515;
+        public const int WM_LBUTTONDOWN = 513;
+        public const int WM_LBUTTONUP = 514;
+        public const int WM_MBUTTONDBLCLK = 521;
+        public const int WM_MBUTTONDOWN = 519;
+        public const int WM_MBUTTONUP = 520;
+        public const int WM_MDIACTIVATE = 546;
+        public const int WM_MDICASCADE = 551;
+        public const int WM_MDICREATE = 544;
+        public const int WM_MDIDESTROY = 545;
+        public const int WM_MDIGETACTIVE = 553;
+        public const int WM_MDIICONARRANGE = 552;
+        public const int WM_MDIMAXIMIZE = 549;
+        public const int WM_MDINEXT = 548;
+        public const int WM_MDIREFRESHMENU = 564;
+        public const int WM_MDIRESTORE = 547;
+        public const int WM_MDISETMENU = 560;
+        public const int WM_MDITILE = 550;
+        public const int WM_MEASUREITEM = 44;
+        public const int WM_MENUCHAR = 288;
+        public const int WM_MENUSELECT = 287;
+        public const int WM_MOUSEACTIVATE = 33;
+        public const int WM_MOUSEFIRST = 512;
+        public const int WM_MOUSEHOVER = 673;
+        public const int WM_MOUSELAST = 522;
+        public const int WM_MOUSELEAVE = 675;
+        public const int WM_MOUSEMOVE = 512;
+        public const int WM_MOUSEWHEEL = 522;
+        public const int WM_MOVE = 3;
+        public const int WM_MOVING = 534;
+        public const int WM_NCACTIVATE = 134;
+        public const int WM_NCCALCSIZE = 131;
+        public const int WM_NCCREATE = 129;
+        public const int WM_NCDESTROY = 130;
+        public const int WM_NCHITTEST = 132;
+        public const int WM_NCLBUTTONDBLCLK = 163;
+        public const int WM_NCLBUTTONDOWN = 161;
+        public const int WM_NCLBUTTONUP = 162;
+        public const int WM_NCMBUTTONDBLCLK = 169;
+        public const int WM_NCMBUTTONDOWN = 167;
+        public const int WM_NCMBUTTONUP = 168;
+        public const int WM_NCMOUSEMOVE = 160;
+        public const int WM_NCPAINT = 133;
+        public const int WM_NCRBUTTONDBLCLK = 166;
+        public const int WM_NCRBUTTONDOWN = 164;
+        public const int WM_NCRBUTTONUP = 165;
+        public const int WM_NCXBUTTONDBLCLK = 173;
+        public const int WM_NCXBUTTONDOWN = 171;
+        public const int WM_NCXBUTTONUP = 172;
+        public const int WM_NEXTDLGCTL = 40;
+        public const int WM_NEXTMENU = 531;
+        public const int WM_NOTIFY = 78;
+        public const int WM_NOTIFYFORMAT = 85;
+        public const int WM_NULL = 0;
+        public const int WM_PAINT = 15;
+        public const int WM_PAINTCLIPBOARD = 777;
+        public const int WM_PAINTICON = 38;
+        public const int WM_PALETTECHANGED = 785;
+        public const int WM_PALETTEISCHANGING = 784;
+        public const int WM_PARENTNOTIFY = 528;
+        public const int WM_PASTE = 770;
+        public const int WM_PENWINFIRST = 896;
+        public const int WM_PENWINLAST = 911;
+        public const int WM_POWER = 72;
+        public const int WM_POWERBROADCAST = 536;
+        public const int WM_PRINT = 791;
+        public const int WM_PRINTCLIENT = 792;
+        public const int WM_QUERYDRAGICON = 55;
+        public const int WM_QUERYENDSESSION = 17;
+        public const int WM_QUERYNEWPALETTE = 783;
+        public const int WM_QUERYOPEN = 19;
+        public const int WM_QUERYUISTATE = 297;
+        public const int WM_QUEUESYNC = 35;
+        public const int WM_QUIT = 18;
+        public const int WM_RBUTTONDBLCLK = 518;
+        public const int WM_RBUTTONDOWN = 516;
+        public const int WM_RBUTTONUP = 517;
+        public const int WM_REFLECT = 8192;
+        public const int WM_RENDERALLFORMATS = 774;
+        public const int WM_RENDERFORMAT = 773;
+        public const int WM_SETCURSOR = 32;
+        public const int WM_SETFOCUS = 7;
+        public const int WM_SETFONT = 48;
+        public const int WM_SETHOTKEY = 50;
+        public const int WM_SETICON = 128;
+        public const int WM_SETREDRAW = 11;
+        public const int WM_SETTEXT = 12;
+        public const int WM_SETTINGCHANGE = 26;
+        public const int WM_SHOWWINDOW = 24;
+        public const int WM_SIZE = 5;
+        public const int WM_SIZECLIPBOARD = 779;
+        public const int WM_SIZING = 532;
+        public const int WM_SPOOLERSTATUS = 42;
+        public const int WM_STYLECHANGED = 125;
+        public const int WM_STYLECHANGING = 124;
+        public const int WM_SYSCHAR = 262;
+        public const int WM_SYSCOLORCHANGE = 21;
+        public const int WM_SYSCOMMAND = 274;
+        public const int WM_SYSDEADCHAR = 263;
+        public const int WM_SYSKEYDOWN = 260;
+        public const int WM_SYSKEYUP = 261;
+        public const int WM_TASKBAR_CREATED = 49286;
+        public const int WM_TCARD = 82;
+        public const int WM_TIMECHANGE = 30;
+        public const int WM_TIMER = 275;
+        public const int WM_TRAYMOUSEMESSAGE = 2048;
+        public const int WM_UNDO = 772;
+        public const int WM_UNINITMENUPOPUP = 293;
+        public const int WM_UPDATEUISTATE = 296;
+        public const int WM_USER = 1024;
+        public const int WM_USERCHANGED = 84;
+        public const int WM_VKEYTOITEM = 46;
+        public const int WM_VSCROLL = 277;
+        public const int WM_VSCROLLCLIPBOARD = 778;
+        public const int WM_WINDOWPOSCHANGED = 71;
+        public const int WM_WINDOWPOSCHANGING = 70;
+        public const int WM_WININICHANGE = 26;
+        public const int WM_XBUTTONDBLCLK = 525;
+        public const int WM_XBUTTONDOWN = 523;
+        public const int WM_XBUTTONUP = 524;
+        public const int WPF_SETMINPOSITION = 1;
+        public const int WS_BORDER = 8388608;
+        public const int WS_CAPTION = 12582912;
+        public const int WS_CHILD = 1073741824;
+        public const int WS_CLIPCHILDREN = 33554432;
+        public const int WS_CLIPSIBLINGS = 67108864;
+        public const int WS_DISABLED = 134217728;
+        public const int WS_DLGFRAME = 4194304;
+        public const int WS_EX_APPWINDOW = 262144;
+        public const int WS_EX_CLIENTEDGE = 512;
+        public const int WS_EX_CONTEXTHELP = 1024;
+        public const int WS_EX_CONTROLPARENT = 65536;
+        public const int WS_EX_DLGMODALFRAME = 1;
+        public const int WS_EX_LAYERED = 524288;
+        public const int WS_EX_LAYOUTRTL = 4194304;
+        public const int WS_EX_LEFT = 0;
+        public const int WS_EX_LEFTSCROLLBAR = 16384;
+        public const int WS_EX_MDICHILD = 64;
+        public const int WS_EX_NOINHERITLAYOUT = 1048576;
+        public const int WS_EX_RIGHT = 4096;
+        public const int WS_EX_RTLREADING = 8192;
+        public const int WS_EX_STATICEDGE = 131072;
+        public const int WS_EX_TOOLWINDOW = 128;
+        public const int WS_EX_TOPMOST = 8;
+        public const int WS_HSCROLL = 1048576;
+        public const int WS_MAXIMIZE = 16777216;
+        public const int WS_MAXIMIZEBOX = 65536;
+        public const int WS_MINIMIZE = 536870912;
+        public const int WS_MINIMIZEBOX = 131072;
+        public const int WS_OVERLAPPED = 0;
+        public const int WS_POPUP = -2147483648;
+        public const int WS_SYSMENU = 524288;
+        public const int WS_TABSTOP = 65536;
+        public const int WS_THICKFRAME = 262144;
+        public const int WS_VISIBLE = 268435456;
+        public const int WS_VSCROLL = 2097152;
+        public const int WSF_VISIBLE = 1;
+    }
+    public class static NativeMethods
+    {
+        public static System.IntPtr GetWindowLong(System.IntPtr hWnd, Topics.Radical.Win32.WindowLong index) { }
+        public static System.IntPtr SetWindowLong(System.IntPtr hWnd, Topics.Radical.Win32.WindowLong index, System.IntPtr value) { }
+    }
+    public enum WindowLong
+    {
+        WindowProc = -4,
+        HInstance = -6,
+        HWndParent = -8,
+        Style = -16,
+        ExStyle = -20,
+        UserData = -21,
+        ID = -12,
+    }
+}

--- a/src/net45/Test.Radical/API/APIApprovals.cs
+++ b/src/net45/Test.Radical/API/APIApprovals.cs
@@ -1,0 +1,24 @@
+﻿using ApprovalTests;
+using ApprovalTests.Reporters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PublicApiGenerator;
+using System.Runtime.CompilerServices;
+using Topics.Radical.ComponentModel.Messaging;
+
+namespace Test.Radical.API
+{
+    [TestClass]
+    public class APIApprovals
+    {
+        [TestMethod]
+        [TestCategory("APIApprovals")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [UseReporter(typeof(DiffReporter))]
+        public void Approve_FXV45_API()
+        {
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(IMessageBroker).Assembly);
+
+            Approvals.Verify(publicApi);
+        }
+    }
+}

--- a/src/net45/Test.Radical/App_Packages/PublicApiGenerator.6.1.0-beta2/ApiGenerator.cs
+++ b/src/net45/Test.Radical/App_Packages/PublicApiGenerator.6.1.0-beta2/ApiGenerator.cs
@@ -1,0 +1,799 @@
+﻿using System;
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CSharp;
+using Mono.Cecil;
+using Mono.Cecil.Rocks;
+using ICustomAttributeProvider = Mono.Cecil.ICustomAttributeProvider;
+using TypeAttributes = System.Reflection.TypeAttributes;
+using System.Globalization;
+
+// ReSharper disable BitwiseOperatorOnEnumWithoutFlags
+namespace PublicApiGenerator
+{
+    public static class ApiGenerator
+    {
+        public static string GeneratePublicApi(Assembly assemby, Type[] includeTypes = null, bool shouldIncludeAssemblyAttributes = true)
+        {
+            using (var assemblyResolver = new DefaultAssemblyResolver())
+            {
+                var assemblyPath = assemby.Location;
+                assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
+
+                var readSymbols = File.Exists(Path.ChangeExtension(assemblyPath, ".pdb"));
+                using (var asm = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters(ReadingMode.Deferred)
+                {
+                    ReadSymbols = readSymbols,
+                    AssemblyResolver = assemblyResolver,
+                }))
+                {
+                    return CreatePublicApiForAssembly(asm, tr => includeTypes == null || includeTypes.Any(t => t.FullName == tr.FullName && t.Assembly.FullName == tr.Module.Assembly.FullName), shouldIncludeAssemblyAttributes);
+                }
+            }
+        }
+
+        // TODO: Assembly references?
+        // TODO: Better handle namespaces - using statements? - requires non-qualified type names
+        static string CreatePublicApiForAssembly(AssemblyDefinition assembly, Func<TypeDefinition, bool> shouldIncludeType, bool shouldIncludeAssemblyAttributes)
+        {
+            var publicApiBuilder = new StringBuilder();
+            var cgo = new CodeGeneratorOptions
+            {
+                BracingStyle = "C",
+                BlankLinesBetweenMembers = false,
+                VerbatimOrder = false
+            };
+
+            using (var provider = new CSharpCodeProvider())
+            {
+                var compileUnit = new CodeCompileUnit();
+                if (shouldIncludeAssemblyAttributes && assembly.HasCustomAttributes)
+                {
+                    PopulateCustomAttributes(assembly, compileUnit.AssemblyCustomAttributes);
+                }
+
+                var publicTypes = assembly.Modules.SelectMany(m => m.GetTypes())
+                    .Where(t => !t.IsNested && ShouldIncludeType(t) && shouldIncludeType(t))
+                    .OrderBy(t => t.FullName);
+                foreach (var publicType in publicTypes)
+                {
+                    var @namespace = compileUnit.Namespaces.Cast<CodeNamespace>()
+                        .FirstOrDefault(n => n.Name == publicType.Namespace);
+                    if (@namespace == null)
+                    {
+                        @namespace = new CodeNamespace(publicType.Namespace);
+                        compileUnit.Namespaces.Add(@namespace);
+                    }
+
+                    var typeDeclaration = CreateTypeDeclaration(publicType);
+                    @namespace.Types.Add(typeDeclaration);
+                }
+
+                using (var writer = new StringWriter())
+                {
+                    provider.GenerateCodeFromCompileUnit(compileUnit, writer, cgo);
+                    var typeDeclarationText = NormaliseGeneratedCode(writer);
+                    publicApiBuilder.AppendLine(typeDeclarationText);
+                }
+            }
+            return NormaliseLineEndings(publicApiBuilder.ToString().Trim());
+        }
+
+        static string NormaliseLineEndings(string value)
+        {
+            return Regex.Replace(value, @"\r\n|\n\r|\r|\n", Environment.NewLine);
+        }
+
+        static bool IsDelegate(TypeDefinition publicType)
+        {
+            return publicType.BaseType != null && publicType.BaseType.FullName == "System.MulticastDelegate";
+        }
+
+        static bool ShouldIncludeType(TypeDefinition t)
+        {
+            return (t.IsPublic || t.IsNestedPublic || t.IsNestedFamily) && !IsCompilerGenerated(t);
+        }
+
+        static bool ShouldIncludeMember(IMemberDefinition m)
+        {
+            return !IsCompilerGenerated(m) && !IsDotNetTypeMember(m) && !(m is FieldDefinition);
+        }
+
+        static bool IsCompilerGenerated(IMemberDefinition m)
+        {
+            return m.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
+        }
+
+        static bool IsDotNetTypeMember(IMemberDefinition m)
+        {
+            if (m.DeclaringType == null || m.DeclaringType.FullName == null)
+                return false;
+            return m.DeclaringType.FullName.StartsWith("System") || m.DeclaringType.FullName.StartsWith("Microsoft");
+        }
+
+        static void AddMemberToTypeDeclaration(CodeTypeDeclaration typeDeclaration, IMemberDefinition memberInfo)
+        {
+            var methodDefinition = memberInfo as MethodDefinition;
+            if (methodDefinition != null)
+            {
+                if (methodDefinition.IsConstructor)
+                    AddCtorToTypeDeclaration(typeDeclaration, methodDefinition);
+                else
+                    AddMethodToTypeDeclaration(typeDeclaration, methodDefinition);
+            }
+            else if (memberInfo is PropertyDefinition)
+            {
+                AddPropertyToTypeDeclaration(typeDeclaration, (PropertyDefinition) memberInfo);
+            }
+            else if (memberInfo is EventDefinition)
+            {
+                typeDeclaration.Members.Add(GenerateEvent((EventDefinition)memberInfo));
+            }
+            else if (memberInfo is FieldDefinition)
+            {
+                AddFieldToTypeDeclaration(typeDeclaration, (FieldDefinition) memberInfo);
+            }
+        }
+
+        static string NormaliseGeneratedCode(StringWriter writer)
+        {
+            var gennedClass = writer.ToString();
+            const string autoGeneratedHeader = @"^//-+\s*$.*^//-+\s*$";
+            const string emptyGetSet = @"\s+{\s+get\s+{\s+}\s+set\s+{\s+}\s+}";
+            const string emptyGet = @"\s+{\s+get\s+{\s+}\s+}";
+            const string emptySet = @"\s+{\s+set\s+{\s+}\s+}";
+            const string getSet = @"\s+{\s+get;\s+set;\s+}";
+            const string get = @"\s+{\s+get;\s+}";
+            const string set = @"\s+{\s+set;\s+}";
+            gennedClass = Regex.Replace(gennedClass, autoGeneratedHeader, string.Empty,
+                RegexOptions.IgnorePatternWhitespace | RegexOptions.Multiline | RegexOptions.Singleline);
+            gennedClass = Regex.Replace(gennedClass, emptyGetSet, " { get; set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, getSet, " { get; set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, emptyGet, " { get; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, emptySet, " { set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, get, " { get; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, set, " { set; }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, @"\s+{\s+}", " { }", RegexOptions.IgnorePatternWhitespace);
+            gennedClass = Regex.Replace(gennedClass, @"\)\s+;", ");", RegexOptions.IgnorePatternWhitespace);
+            return gennedClass;
+        }
+
+        static CodeTypeDeclaration CreateTypeDeclaration(TypeDefinition publicType)
+        {
+            if (IsDelegate(publicType))
+                return CreateDelegateDeclaration(publicType);
+
+            bool @static = false;
+            TypeAttributes attributes = 0;
+            if (publicType.IsPublic || publicType.IsNestedPublic)
+                attributes |= TypeAttributes.Public;
+            if (publicType.IsNestedFamily)
+                attributes |= TypeAttributes.NestedFamily;
+            if (publicType.IsSealed && !publicType.IsAbstract)
+                attributes |= TypeAttributes.Sealed;
+            else if (!publicType.IsSealed && publicType.IsAbstract && !publicType.IsInterface)
+                attributes |= TypeAttributes.Abstract;
+            else if (publicType.IsSealed && publicType.IsAbstract)
+                @static = true;
+
+            // Static support is a hack. CodeDOM does support it, and this isn't
+            // correct C#, but it's good enough for our API outline
+            var name = publicType.Name;
+
+            var index = name.IndexOf('`');
+            if (index != -1)
+                name = name.Substring(0, index);
+            var declaration = new CodeTypeDeclaration(@static ? "static " + name : name)
+            {
+                CustomAttributes = CreateCustomAttributes(publicType),
+                // TypeAttributes must be specified before the IsXXX as they manipulate TypeAttributes!
+                TypeAttributes = attributes,
+                IsClass = publicType.IsClass,
+                IsEnum = publicType.IsEnum,
+                IsInterface = publicType.IsInterface,
+                IsStruct = publicType.IsValueType && !publicType.IsPrimitive && !publicType.IsEnum,
+            };
+
+            if (declaration.IsInterface && publicType.BaseType != null)
+                throw new NotImplementedException("Base types for interfaces needs testing");
+
+            PopulateGenericParameters(publicType, declaration.TypeParameters);
+
+            if (publicType.BaseType != null && ShouldOutputBaseType(publicType))
+            {
+                if (publicType.BaseType.FullName == "System.Enum")
+                {
+                    var underlyingType = publicType.GetEnumUnderlyingType();
+                    if (underlyingType.FullName != "System.Int32")
+                        declaration.BaseTypes.Add(CreateCodeTypeReference(underlyingType));
+                }
+                else
+                    declaration.BaseTypes.Add(CreateCodeTypeReference(publicType.BaseType));
+            }
+            foreach(var @interface in publicType.Interfaces.OrderBy(i => i.InterfaceType.FullName)
+                .Select(t => new { Reference = t, Definition = t.InterfaceType.Resolve() })
+                .Where(t => ShouldIncludeType(t.Definition))
+                .Select(t => t.Reference))
+                declaration.BaseTypes.Add(CreateCodeTypeReference(@interface.InterfaceType));
+
+            foreach (var memberInfo in publicType.GetMembers().Where(ShouldIncludeMember).OrderBy(m => m.Name))
+                AddMemberToTypeDeclaration(declaration, memberInfo);
+
+            // Fields should be in defined order for an enum
+            var fields = !publicType.IsEnum
+                ? publicType.Fields.OrderBy(f => f.Name)
+                : (IEnumerable<FieldDefinition>)publicType.Fields;
+            foreach (var field in fields)
+                AddMemberToTypeDeclaration(declaration, field);
+
+            foreach (var nestedType in publicType.NestedTypes.Where(ShouldIncludeType).OrderBy(t => t.FullName))
+            {
+                var nestedTypeDeclaration = CreateTypeDeclaration(nestedType);
+                declaration.Members.Add(nestedTypeDeclaration);
+            }
+
+            return declaration;
+        }
+
+        static CodeTypeDeclaration CreateDelegateDeclaration(TypeDefinition publicType)
+        {
+            var invokeMethod = publicType.Methods.Single(m => m.Name == "Invoke");
+            var name = publicType.Name;
+            var index = name.IndexOf('`');
+            if (index != -1)
+                name = name.Substring(0, index);
+            var declaration = new CodeTypeDelegate(name)
+            {
+                Attributes = MemberAttributes.Public,
+                CustomAttributes = CreateCustomAttributes(publicType),
+                ReturnType = CreateCodeTypeReference(invokeMethod.ReturnType),
+            };
+
+            // CodeDOM. No support. Return type attributes.
+            PopulateCustomAttributes(invokeMethod.MethodReturnType, declaration.CustomAttributes, type => ModifyCodeTypeReference(type, "return:"));
+            PopulateGenericParameters(publicType, declaration.TypeParameters);
+            PopulateMethodParameters(invokeMethod, declaration.Parameters);
+
+            // Of course, CodeDOM doesn't support generic type parameters for delegates. Of course.
+            if (declaration.TypeParameters.Count > 0)
+            {
+                var parameterNames = from parameterType in declaration.TypeParameters.Cast<CodeTypeParameter>()
+                    select parameterType.Name;
+                declaration.Name = string.Format(CultureInfo.InvariantCulture, "{0}<{1}>", declaration.Name, string.Join(", ", parameterNames));
+            }
+
+            return declaration;
+        }
+
+        static bool ShouldOutputBaseType(TypeDefinition publicType)
+        {
+            return publicType.BaseType.FullName != "System.Object" && publicType.BaseType.FullName != "System.ValueType";
+        }
+
+        static void PopulateGenericParameters(IGenericParameterProvider publicType, CodeTypeParameterCollection parameters)
+        {
+            foreach (var parameter in publicType.GenericParameters)
+            {
+                if (parameter.HasCustomAttributes)
+                    throw new NotImplementedException("Attributes on type parameters is not supported. And weird");
+
+                // A little hacky. Means we get "in" and "out" prefixed on any constraints, but it's either that
+                // or add it as a custom attribute, which looks even weirder
+                var name = parameter.Name;
+                if (parameter.IsCovariant)
+                    name = "out " + name;
+                if (parameter.IsContravariant)
+                    name = "in " + name;
+
+                var typeParameter = new CodeTypeParameter(name)
+                {
+                    HasConstructorConstraint =
+                        parameter.HasDefaultConstructorConstraint && !parameter.HasNotNullableValueTypeConstraint
+                };
+                if (parameter.HasNotNullableValueTypeConstraint)
+                    typeParameter.Constraints.Add(" struct"); // Extra space is a hack!
+                if (parameter.HasReferenceTypeConstraint)
+                    typeParameter.Constraints.Add(" class");
+                foreach (var constraint in parameter.Constraints.Where(t => t.FullName != "System.ValueType"))
+                {
+                    typeParameter.Constraints.Add(CreateCodeTypeReference(constraint.GetElementType()));
+                }
+                parameters.Add(typeParameter);
+            }
+        }
+
+        static CodeAttributeDeclarationCollection CreateCustomAttributes(ICustomAttributeProvider type)
+        {
+            var attributes = new CodeAttributeDeclarationCollection();
+            PopulateCustomAttributes(type, attributes);
+            return attributes;
+        }
+
+        static void PopulateCustomAttributes(ICustomAttributeProvider type,
+            CodeAttributeDeclarationCollection attributes)
+        {
+            PopulateCustomAttributes(type, attributes, ctr => ctr);
+        }
+
+        static void PopulateCustomAttributes(ICustomAttributeProvider type,
+            CodeAttributeDeclarationCollection attributes, Func<CodeTypeReference, CodeTypeReference> codeTypeModifier)
+        {
+            foreach (var customAttribute in type.CustomAttributes.Where(ShouldIncludeAttribute).OrderBy(a => a.AttributeType.FullName).ThenBy(a => ConvertAttrbuteToCode(codeTypeModifier, a)))
+            {
+                var attribute = GenerateCodeAttributeDeclaration(codeTypeModifier, customAttribute);
+                attributes.Add(attribute);
+            }
+        }
+
+        static CodeAttributeDeclaration GenerateCodeAttributeDeclaration(Func<CodeTypeReference, CodeTypeReference> codeTypeModifier, CustomAttribute customAttribute)
+        {
+            var attribute = new CodeAttributeDeclaration(codeTypeModifier(CreateCodeTypeReference(customAttribute.AttributeType)));
+            foreach (var arg in customAttribute.ConstructorArguments)
+            {
+                attribute.Arguments.Add(new CodeAttributeArgument(CreateInitialiserExpression(arg)));
+            }
+            foreach (var field in customAttribute.Fields.OrderBy(f => f.Name))
+            {
+                attribute.Arguments.Add(new CodeAttributeArgument(field.Name, CreateInitialiserExpression(field.Argument)));
+            }
+            foreach (var property in customAttribute.Properties.OrderBy(p => p.Name))
+            {
+                attribute.Arguments.Add(new CodeAttributeArgument(property.Name, CreateInitialiserExpression(property.Argument)));
+            }
+            return attribute;
+        }
+
+        // Litee: This method is used for additional sorting of custom attributes when multiple values are allowed
+        static object ConvertAttrbuteToCode(Func<CodeTypeReference, CodeTypeReference> codeTypeModifier, CustomAttribute customAttribute)
+        {
+            using (var provider = new CSharpCodeProvider())
+            {
+                var cgo = new CodeGeneratorOptions
+                {
+                    BracingStyle = "C",
+                    BlankLinesBetweenMembers = false,
+                    VerbatimOrder = false
+                };
+                var attribute = GenerateCodeAttributeDeclaration(codeTypeModifier, customAttribute);
+                var declaration = new CodeTypeDeclaration("DummyClass")
+                {
+                    CustomAttributes = new CodeAttributeDeclarationCollection(new[] { attribute }),
+                };
+                using (var writer = new StringWriter())
+                {
+                    provider.GenerateCodeFromType(declaration, writer, cgo);
+                    return writer.ToString();
+                }
+            }
+        }
+
+        static readonly HashSet<string> SkipAttributeNames = new HashSet<string>
+        {
+            "System.CodeDom.Compiler.GeneratedCodeAttribute",
+            "System.ComponentModel.EditorBrowsableAttribute",
+            "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
+            "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
+            "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
+            "System.Runtime.CompilerServices.ExtensionAttribute",
+            "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
+            "System.Reflection.DefaultMemberAttribute",
+            "System.Diagnostics.DebuggableAttribute",
+            "System.Diagnostics.DebuggerNonUserCodeAttribute",
+            "System.Diagnostics.DebuggerStepThroughAttribute",
+            "System.Reflection.AssemblyCompanyAttribute",
+            "System.Reflection.AssemblyConfigurationAttribute",
+            "System.Reflection.AssemblyCopyrightAttribute",
+            "System.Reflection.AssemblyDescriptionAttribute",
+            "System.Reflection.AssemblyFileVersionAttribute",
+            "System.Reflection.AssemblyInformationalVersionAttribute",
+            "System.Reflection.AssemblyProductAttribute",
+            "System.Reflection.AssemblyTitleAttribute",
+            "System.Reflection.AssemblyTrademarkAttribute"
+        };
+
+        static bool ShouldIncludeAttribute(CustomAttribute attribute)
+        {
+            var attributeTypeDefinition = attribute.AttributeType.Resolve();
+            return !SkipAttributeNames.Contains(attribute.AttributeType.FullName) && attributeTypeDefinition.IsPublic;
+        }
+
+        static CodeExpression CreateInitialiserExpression(CustomAttributeArgument attributeArgument)
+        {
+            if (attributeArgument.Value is CustomAttributeArgument)
+            {
+                return CreateInitialiserExpression((CustomAttributeArgument) attributeArgument.Value);
+            }
+
+            if (attributeArgument.Value is CustomAttributeArgument[])
+            {
+                var initialisers = from argument in (CustomAttributeArgument[]) attributeArgument.Value
+                    select CreateInitialiserExpression(argument);
+                return new CodeArrayCreateExpression(CreateCodeTypeReference(attributeArgument.Type), initialisers.ToArray());
+            }
+
+            var type = attributeArgument.Type.Resolve();
+            var value = attributeArgument.Value;
+            if (type.BaseType != null && type.BaseType.FullName == "System.Enum")
+            {
+                var originalValue = Convert.ToInt64(value);
+                if (type.CustomAttributes.Any(a => a.AttributeType.FullName == "System.FlagsAttribute"))
+                {
+                    //var allFlags = from f in type.Fields
+                    //    where f.Constant != null
+                    //    let v = Convert.ToInt64(f.Constant)
+                    //    where v == 0 || (originalValue & v) != 0
+                    //    select (CodeExpression)new CodeFieldReferenceExpression(typeExpression, f.Name);
+                    //return allFlags.Aggregate((current, next) => new CodeBinaryOperatorExpression(current, CodeBinaryOperatorType.BitwiseOr, next));
+
+                    // I'd rather use the above, as it's just using the CodeDOM, but it puts
+                    // brackets around each CodeBinaryOperatorExpression
+                    var flags = from f in type.Fields
+                                where f.Constant != null
+                                let v = Convert.ToInt64(f.Constant)
+                                where v == 0 || (originalValue & v) != 0
+                                select type.FullName + "." + f.Name;
+                    return new CodeSnippetExpression(flags.Aggregate((current, next) => current + " | " + next));
+                }
+
+                var allFlags = from f in type.Fields
+                               where f.Constant != null
+                               let v = Convert.ToInt64(f.Constant)
+                               where v == originalValue
+                               select new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(CreateCodeTypeReference(type)), f.Name);
+                return allFlags.FirstOrDefault();
+            }
+
+            if (type.FullName == "System.Type" && value is TypeReference)
+            {
+                return new CodeTypeOfExpression(CreateCodeTypeReference((TypeReference)value));
+            }
+
+            if (value is string)
+            {
+                // CodeDOM outputs a verbatim string. Any string with \n is treated as such, so normalise
+                // it to make it easier for comparisons
+                value = Regex.Replace((string)value, @"\n", "\\n");
+                value = Regex.Replace((string)value, @"\r\n|\r\\n", "\\r\\n");
+            }
+
+            return new CodePrimitiveExpression(value);
+        }
+
+        static void AddCtorToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member)
+        {
+            if (member.IsAssembly || member.IsPrivate)
+                return;
+
+            var method = new CodeConstructor
+            {
+                CustomAttributes = CreateCustomAttributes(member),
+                Name = member.Name,
+                Attributes = GetMethodAttributes(member)
+            };
+            PopulateMethodParameters(member, method.Parameters);
+
+            typeDeclaration.Members.Add(method);
+        }
+
+        static void AddMethodToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member)
+        {
+            if (member.IsAssembly || member.IsPrivate || member.IsSpecialName)
+                return;
+
+            var returnType = CreateCodeTypeReference(member.ReturnType);
+
+            var method = new CodeMemberMethod
+            {
+                Name = member.Name,
+                Attributes = GetMethodAttributes(member),
+                CustomAttributes = CreateCustomAttributes(member),
+                ReturnType = returnType,
+            };
+            PopulateCustomAttributes(member.MethodReturnType, method.ReturnTypeCustomAttributes);
+            PopulateGenericParameters(member, method.TypeParameters);
+            PopulateMethodParameters(member, method.Parameters, IsExtensionMethod(member));
+
+            typeDeclaration.Members.Add(method);
+        }
+
+        static bool IsExtensionMethod(ICustomAttributeProvider method)
+        {
+            return method.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.ExtensionAttribute");
+        }
+
+        static void PopulateMethodParameters(IMethodSignature member,
+            CodeParameterDeclarationExpressionCollection parameters, bool isExtension = false)
+        {
+            foreach (var parameter in member.Parameters)
+            {
+                FieldDirection direction = 0;
+                if (parameter.IsOut)
+                    direction |= FieldDirection.Out;
+                else if (parameter.ParameterType.IsByReference)
+                    direction |= FieldDirection.Ref;
+
+                var parameterType = parameter.ParameterType.IsByReference
+                    ? parameter.ParameterType.GetElementType()
+                    : parameter.ParameterType;
+
+                var type = CreateCodeTypeReference(parameterType);
+
+                if (isExtension)
+                {
+                    type = ModifyCodeTypeReference(type, "this");
+                    isExtension = false;
+                }
+
+                var name = parameter.HasConstant
+                    ? string.Format(CultureInfo.InvariantCulture, "{0} = {1}", parameter.Name, FormatParameterConstant(parameter))
+                    : parameter.Name;
+                var expression = new CodeParameterDeclarationExpression(type, name)
+                {
+                    Direction = direction,
+                    CustomAttributes = CreateCustomAttributes(parameter)
+                };
+                parameters.Add(expression);
+            }
+        }
+
+        static object FormatParameterConstant(IConstantProvider parameter)
+        {
+            return parameter.Constant is string ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", parameter.Constant) : (parameter.Constant ?? "null");
+        }
+
+        static MemberAttributes GetMethodAttributes(MethodDefinition method)
+        {
+            MemberAttributes access = 0;
+            if (method.IsFamily)
+                access = MemberAttributes.Family;
+            if (method.IsPublic)
+                access = MemberAttributes.Public;
+            if (method.IsAssembly)
+                access = MemberAttributes.Assembly;
+            if (method.IsFamilyAndAssembly)
+                access = MemberAttributes.FamilyAndAssembly;
+            if (method.IsFamilyOrAssembly)
+                access = MemberAttributes.FamilyOrAssembly;
+
+            MemberAttributes scope = 0;
+            if (method.IsStatic)
+                scope |= MemberAttributes.Static;
+            if (method.IsFinal || !method.IsVirtual)
+                scope |= MemberAttributes.Final;
+            if (method.IsAbstract)
+                scope |= MemberAttributes.Abstract;
+            if (method.IsVirtual && !method.IsNewSlot)
+                scope |= MemberAttributes.Override;
+
+            MemberAttributes vtable = 0;
+            if (IsHidingMethod(method))
+                vtable = MemberAttributes.New;
+
+            return access | scope | vtable;
+        }
+
+        static bool IsHidingMethod(MethodDefinition method)
+        {
+            var typeDefinition = method.DeclaringType;
+
+            // If we're an interface, just try and find any method with the same signature
+            // in any of the interfaces that we implement
+            if (typeDefinition.IsInterface)
+            {
+                var interfaceMethods = from @interfaceReference in typeDefinition.Interfaces
+                    let interfaceDefinition = @interfaceReference.InterfaceType.Resolve()
+                    where interfaceDefinition != null
+                    select interfaceDefinition.Methods;
+
+                return interfaceMethods.Any(ms => MetadataResolver.GetMethod(ms, method) != null);
+            }
+
+            // If we're not an interface, find a base method that isn't virtual
+            return !method.IsVirtual && GetBaseTypes(typeDefinition).Any(d => MetadataResolver.GetMethod(d.Methods, method) != null);
+        }
+
+        static IEnumerable<TypeDefinition> GetBaseTypes(TypeDefinition type)
+        {
+            var baseType = type.BaseType;
+            while (baseType != null)
+            {
+                var definition = baseType.Resolve();
+                if (definition == null)
+                    yield break;
+                yield return definition;
+
+                baseType = baseType.DeclaringType;
+            }
+        }
+
+        static void AddPropertyToTypeDeclaration(CodeTypeDeclaration typeDeclaration, PropertyDefinition member)
+        {
+            var getterAttributes = member.GetMethod != null ? GetMethodAttributes(member.GetMethod) : 0;
+            var setterAttributes = member.SetMethod != null ? GetMethodAttributes(member.SetMethod) : 0;
+
+            if (!HasVisiblePropertyMethod(getterAttributes) && !HasVisiblePropertyMethod(setterAttributes))
+                return;
+
+            var propertyAttributes = GetPropertyAttributes(getterAttributes, setterAttributes);
+
+            var propertyType = member.PropertyType.IsGenericParameter
+                ? new CodeTypeReference(member.PropertyType.Name)
+                : CreateCodeTypeReference(member.PropertyType);
+
+            var property = new CodeMemberProperty
+            {
+                Name = member.Name,
+                Type = propertyType,
+                Attributes = propertyAttributes,
+                CustomAttributes = CreateCustomAttributes(member),
+                HasGet = member.GetMethod != null && HasVisiblePropertyMethod(getterAttributes),
+                HasSet = member.SetMethod != null && HasVisiblePropertyMethod(setterAttributes)
+            };
+
+            // Here's a nice hack, because hey, guess what, the CodeDOM doesn't support
+            // attributes on getters or setters
+            if (member.GetMethod != null && member.GetMethod.HasCustomAttributes)
+            {
+                PopulateCustomAttributes(member.GetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "get:"));
+            }
+            if (member.SetMethod != null && member.SetMethod.HasCustomAttributes)
+            {
+                PopulateCustomAttributes(member.SetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "set:"));
+            }
+
+            foreach (var parameter in member.Parameters)
+            {
+                property.Parameters.Add(
+                    new CodeParameterDeclarationExpression(CreateCodeTypeReference(parameter.ParameterType),
+                        parameter.Name));
+            }
+
+            // TODO: CodeDOM has no support for different access modifiers for getters and setters
+            // TODO: CodeDOM has no support for attributes on setters or getters - promote to property?
+
+            typeDeclaration.Members.Add(property);
+        }
+
+        static MemberAttributes GetPropertyAttributes(MemberAttributes getterAttributes, MemberAttributes setterAttributes)
+        {
+            MemberAttributes access = 0;
+            var getterAccess = getterAttributes & MemberAttributes.AccessMask;
+            var setterAccess = setterAttributes & MemberAttributes.AccessMask;
+            if (getterAccess == MemberAttributes.Public || setterAccess == MemberAttributes.Public)
+                access = MemberAttributes.Public;
+            else if (getterAccess == MemberAttributes.Family || setterAccess == MemberAttributes.Family)
+                access = MemberAttributes.Family;
+            else if (getterAccess == MemberAttributes.FamilyAndAssembly || setterAccess == MemberAttributes.FamilyAndAssembly)
+                access = MemberAttributes.FamilyAndAssembly;
+            else if (getterAccess == MemberAttributes.FamilyOrAssembly || setterAccess == MemberAttributes.FamilyOrAssembly)
+                access = MemberAttributes.FamilyOrAssembly;
+            else if (getterAccess == MemberAttributes.Assembly || setterAccess == MemberAttributes.Assembly)
+                access = MemberAttributes.Assembly;
+            else if (getterAccess == MemberAttributes.Private || setterAccess == MemberAttributes.Private)
+                access = MemberAttributes.Private;
+
+            // Scope should be the same for getter and setter. If one isn't specified, it'll be 0
+            var getterScope = getterAttributes & MemberAttributes.ScopeMask;
+            var setterScope = setterAttributes & MemberAttributes.ScopeMask;
+            var scope = (MemberAttributes) Math.Max((int) getterScope, (int) setterScope);
+
+            // Vtable should be the same for getter and setter. If one isn't specified, it'll be 0
+            var getterVtable = getterAttributes & MemberAttributes.VTableMask;
+            var setterVtable = setterAttributes & MemberAttributes.VTableMask;
+            var vtable = (MemberAttributes) Math.Max((int) getterVtable, (int) setterVtable);
+
+            return access | scope | vtable;
+        }
+
+        static bool HasVisiblePropertyMethod(MemberAttributes attributes)
+        {
+            var access = attributes & MemberAttributes.AccessMask;
+            return access == MemberAttributes.Public || access == MemberAttributes.Family ||
+                   access == MemberAttributes.FamilyOrAssembly;
+        }
+
+        static CodeTypeMember GenerateEvent(EventDefinition eventDefinition)
+        {
+            var @event = new CodeMemberEvent
+            {
+                Name = eventDefinition.Name,
+                Attributes = MemberAttributes.Public | MemberAttributes.Final,
+                CustomAttributes = CreateCustomAttributes(eventDefinition),
+                Type = CreateCodeTypeReference(eventDefinition.EventType)
+            };
+
+            return @event;
+        }
+
+        static void AddFieldToTypeDeclaration(CodeTypeDeclaration typeDeclaration, FieldDefinition memberInfo)
+        {
+            if (memberInfo.IsPrivate || memberInfo.IsAssembly || memberInfo.IsSpecialName)
+                return;
+
+            MemberAttributes attributes = 0;
+            if (memberInfo.HasConstant)
+                attributes |= MemberAttributes.Const;
+            if (memberInfo.IsFamily)
+                attributes |= MemberAttributes.Family;
+            if (memberInfo.IsPublic)
+                attributes |= MemberAttributes.Public;
+            if (memberInfo.IsStatic && !memberInfo.HasConstant)
+                attributes |= MemberAttributes.Static;
+
+            // TODO: Values for readonly fields are set in the ctor
+            var codeTypeReference = CreateCodeTypeReference(memberInfo.FieldType);
+            if (memberInfo.IsInitOnly)
+                codeTypeReference = MakeReadonly(codeTypeReference);
+            var field = new CodeMemberField(codeTypeReference, memberInfo.Name)
+            {
+                Attributes = attributes,
+                CustomAttributes = CreateCustomAttributes(memberInfo)
+            };
+
+            if (memberInfo.HasConstant)
+                field.InitExpression = new CodePrimitiveExpression(memberInfo.Constant);
+
+            typeDeclaration.Members.Add(field);
+        }
+
+        static CodeTypeReference MakeReadonly(CodeTypeReference typeReference)
+        {
+            return ModifyCodeTypeReference(typeReference, "readonly");
+        }
+
+        static CodeTypeReference ModifyCodeTypeReference(CodeTypeReference typeReference, string modifier)
+        {
+            using (var provider = new CSharpCodeProvider())
+                return new CodeTypeReference(modifier + " " + provider.GetTypeOutput(typeReference));
+        }
+
+        static CodeTypeReference CreateCodeTypeReference(TypeReference type)
+        {
+            var typeName = GetTypeName(type);
+            return new CodeTypeReference(typeName, CreateGenericArguments(type));
+        }
+
+        static string GetTypeName(TypeReference type)
+        {
+            if (type.IsGenericParameter)
+                return type.Name;
+
+            if (!type.IsNested)
+            {
+                return (!string.IsNullOrEmpty(type.Namespace) ? (type.Namespace + ".") : "") + type.Name;
+            }
+
+            return GetTypeName(type.DeclaringType) + "." + type.Name;
+        }
+
+        static CodeTypeReference[] CreateGenericArguments(TypeReference type)
+        {
+            var genericInstance = type as IGenericInstance;
+            if (genericInstance == null) return null;
+
+            var genericArguments = new List<CodeTypeReference>();
+            foreach (var argument in genericInstance.GenericArguments)
+            {
+                genericArguments.Add(CreateCodeTypeReference(argument));
+            }
+            return genericArguments.ToArray();
+        }
+    }
+
+    static class CecilEx
+    {
+        public static IEnumerable<IMemberDefinition> GetMembers(this TypeDefinition type)
+        {
+            return type.Fields.Cast<IMemberDefinition>()
+                .Concat(type.Methods)
+                .Concat(type.Properties)
+                .Concat(type.Events);
+        }
+    }
+}

--- a/src/net45/Test.Radical/Test.Radical.csproj
+++ b/src/net45/Test.Radical/Test.Radical.csproj
@@ -36,6 +36,27 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ApprovalTests, Version=3.0.0.0, Culture=neutral, PublicKeyToken=11bd7d124fc62e0f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ApprovalTests.3.0.13\lib\net40\ApprovalTests.dll</HintPath>
+    </Reference>
+    <Reference Include="ApprovalUtilities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=11bd7d124fc62e0f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ApprovalUtilities.3.0.13\lib\net45\ApprovalUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="ApprovalUtilities.Net45, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ApprovalUtilities.3.0.13\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta6\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>
@@ -51,6 +72,8 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="API\APIApprovals.cs" />
+    <Compile Include="App_Packages\PublicApiGenerator.6.1.0-beta2\ApiGenerator.cs" />
     <Compile Include="Messaging\MessageBrokerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -59,6 +82,12 @@
       <Project>{db4e99f1-3cbe-4e76-9197-d6f884a0f618}</Project>
       <Name>Radical</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="API\APIApprovals.Approve_FXV45_API.approved.txt" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/src/net45/Test.Radical/packages.config
+++ b/src/net45/Test.Radical/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ApprovalTests" version="3.0.13" targetFramework="net45" />
+  <package id="ApprovalUtilities" version="3.0.13" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net45" />
+  <package id="PublicApiGenerator" version="6.1.0-beta2" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Connects to https://github.com/RadicalFx/housekeeping/issues/76

This PR introduces API Approval tests. API Approval tests simplify SemVer handling by comparing the public API surface of an assembly with a predefined one (automatically generated). tests will fail if the public API changes unexpectedly.